### PR TITLE
fixed: added missing functions to init files

### DIFF
--- a/src/glayout/__init__.py
+++ b/src/glayout/__init__.py
@@ -2,19 +2,64 @@
 Glayout - A PDK-agnostic layout automation framework for analog circuit design
 """
 
-from .pdk.mappedpdk import MappedPDK
-from .pdk.sky130_mapped import sky130_mapped_pdk as sky130
-from .pdk.gf180_mapped import gf180_mapped_pdk as gf180
-from .primitives.via_gen import via_stack, via_array
-from .primitives.fet import nmos, pmos, multiplier
-from .primitives.guardring import tapring
-from .util.port_utils import PortTree, rename_ports_by_orientation
-from .util.comp_utils import move, movex, movey, align_comp_to_port
+from .pdk import MappedPDK, SetupPDKFiles, sky130_add_npc
+from .pdk import sky130_mapped_pdk as sky130
+from .pdk import gf180_mapped_pdk as gf180
+from .primitives import via_stack, via_array, nmos, pmos, multiplier, tapring, fet_netlist, mimcap, mimcap_array, resistor
+from .util import evaluate_bbox, center_to_edge_distance, move, movex, movey, to_float, to_decimal, prec_array, prec_center, prec_ref_center, get_padding_points_cc, get_primitive_rectangle, PortTree, parse_direction, proc_angle, ports_inline, ports_parallel, rename_component_ports, rename_ports_by_list, rename_ports_by_orientation, remove_ports_with_prefix, add_ports_perimeter, get_orientation, assert_port_manhattan, assert_ports_perpindicular, set_port_orientation, set_port_width, print_ports, create_private_ports, print_port_tree_all_cells, rectangle, rename_ports_by_orientation, prec_array, prec_ref_center, component_snap_to_grid, get_files_with_extension, write_component_matrix, split_rule, create_ruledeck_python_dictionary_definition, visualize_ruleset
+from .routing import smart_route, generic_route_ab_ba_common_centroid, generic_route_four_transistor_interdigitized, generic_route_two_transistor_interdigitized, parse_port_name, check_route, c_route, L_route, straight_route
 
 __version__ = "0.1.0"
 
 __all__ = [
     "MappedPDK",
+    "SetupPDKFiles",
+    "sky130_add_npc",
+    "fet_netlist",
+    "mimcap",
+    "mimcap_array",
+    "resistor",
+    "evaluate_bbox",
+    "center_to_edge_distance",
+    "to_float",
+    "to_decimal",
+    "prec_array",
+    "prec_center",
+    "prec_ref_center",
+    "get_padding_points_cc",
+    "get_primitive_rectangle",
+    "parse_direction",
+    "proc_angle",
+    "ports_inline",
+    "ports_parallel",
+    "rename_component_ports",
+    "rename_ports_by_list",
+    "remove_ports_with_prefix",
+    "add_ports_perimeter",
+    "get_orientation",
+    "assert_port_manhattan",
+    "assert_ports_perpindicular",
+    "set_port_orientation",
+    "set_port_width",
+    "print_ports",
+    "create_private_ports",
+    "print_port_tree_all_cells",
+    "rectangle",
+    "component_snap_to_grid",
+    "get_files_with_extension",
+    "write_component_matrix",
+    "split_rule",
+    "create_ruledeck_python_dictionary_definition",
+    "visualize_ruleset",
+    "smart_route",
+    "generic_route_ab_ba_common_centroid",
+    "generic_route_four_transistor_interdigitized",
+    "generic_route_two_transistor_interdigitized",
+    "parse_port_name",
+    "check_route",
+    "c_route",
+    "L_route",
+    "straight_route",
     "via_stack",
     "via_array",
     "nmos", 

--- a/src/glayout/pdk/__init__.py
+++ b/src/glayout/pdk/__init__.py
@@ -1,0 +1,8 @@
+from .mappedpdk import MappedPDK, SetupPDKFiles
+
+
+#----------------------------------------------
+
+from .sky130_mapped import sky130_mapped_pdk, sky130_add_npc
+
+from .gf180_mapped import gf180_mapped_pdk

--- a/src/glayout/pdk/gf180_mapped/__init__.py
+++ b/src/glayout/pdk/gf180_mapped/__init__.py
@@ -2,4 +2,4 @@
 Usage at the package level: from pdk.gf180_mapped import gf180_mapped_pdk
 """
 
-from glayout.pdk.gf180_mapped.gf180_mapped import gf180_mapped_pdk
+from .gf180_mapped import gf180_mapped_pdk

--- a/src/glayout/pdk/sky130_mapped/__init__.py
+++ b/src/glayout/pdk/sky130_mapped/__init__.py
@@ -2,4 +2,5 @@
 Usage at the package level: from pdk.sky130_mapped import sky130_mapped_pdk
 """
 
-from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk
+from .sky130_mapped import sky130_mapped_pdk
+from .sky130_add_npc import sky130_add_npc

--- a/src/glayout/primitives/__init__.py
+++ b/src/glayout/primitives/__init__.py
@@ -3,9 +3,10 @@ Glayout primitives module for basic circuit components.
 """
 
 from .via_gen import via_stack, via_array
-from .fet import nmos, pmos, multiplier
+from .fet import nmos, pmos, multiplier, fet_netlist
 from .guardring import tapring
 from .mimcap import mimcap, mimcap_array
+from .resistor import resistor
 
 __all__ = [
     'via_stack',
@@ -13,7 +14,9 @@ __all__ = [
     'nmos',
     'pmos',
     'multiplier',
+    'fet_netlist',
     'tapring',
     'mimcap',
-    'mimcap_array'
+    'mimcap_array',
+    'resistor'
 ] 

--- a/src/glayout/routing/__init__.py
+++ b/src/glayout/routing/__init__.py
@@ -1,0 +1,9 @@
+"""
+Glayout routing module for basic routing functions
+"""
+
+from .smart_route import smart_route, generic_route_ab_ba_common_centroid, generic_route_four_transistor_interdigitized, generic_route_two_transistor_interdigitized, parse_port_name, check_route
+from .c_route import c_route
+from .straight_route import straight_route
+from .L_route import L_route
+

--- a/src/glayout/util/__init__.py
+++ b/src/glayout/util/__init__.py
@@ -1,0 +1,32 @@
+"""
+utils functions
+"""
+
+from .comp_utils import evaluate_bbox, center_to_edge_distance, move, movex, movey, to_float, to_decimal, prec_array, prec_center, prec_ref_center, get_padding_points_cc, get_primitive_rectangle
+from .port_utils import PortTree, parse_direction, proc_angle, ports_inline, ports_parallel, rename_component_ports, rename_ports_by_list, rename_ports_by_orientation, remove_ports_with_prefix, add_ports_perimeter, get_orientation, assert_port_manhattan, assert_ports_perpindicular, set_port_orientation, set_port_width, print_ports, create_private_ports, print_port_tree_all_cells
+from .geometry import rectangle, rename_ports_by_orientation, prec_array, prec_ref_center
+from .snap_to_grid import component_snap_to_grid
+from .component_array_create import get_files_with_extension, write_component_matrix
+from .print_rules import split_rule, create_ruledeck_python_dictionary_definition, visualize_ruleset
+
+
+"""
+Duplicate functions ignored:
+
+| Source File              | Function Name                    | Currently in __init__.py |
+|--------------------------|----------------------------------|--------------------------|
+| comp_utils.py            | align_comp_to_port               | NO                       | ####
+| geometry.py              | evaluate_bbox                    | NO                       | ####
+| geometry.py              | component_snap_to_grid           | NO                       | ####
+| geometry.py              | to_decimal                       | NO                       | ####
+| geometry.py              | to_float                         | NO                       | ####
+| geometry.py              | move                             | NO                       | ####
+| geometry.py              | movex                            | NO                       | ####
+| geometry.py              | movey                            | NO                       | ####
+| geometry.py              | align_comp_to_port               | NO                       | ####
+| geometry.py              | rename_ports_by_list             | NO                       | ####
+| routing.py               | straight_route                   | NO                       | ####
+| routing.py               | L_route                          | NO                       | ####
+| routing.py               | c_route                          | NO                       | ####
+
+"""


### PR DESCRIPTION
users can now directly do "from glayout import function", instead of having to do "from glayout.path... import function"
duplicate functions have been marked with a comment, incase any changes need to be made