### PR TITLE
Contributer Guide Update Part 3: Update unavailable link to guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For detailed documentation, please visit our [documentation site](https://glayou
 
 ## Contributing
 
-We welcome contributions! Please see our [Contributing Guide](docs/contributer_guide.md) for details.
+We welcome contributions! Please see our [Contributing Guide](docs/contributor_guide.md) for details.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For detailed documentation, please visit our [documentation site](https://glayou
 
 ## Contributing
 
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
+We welcome contributions! Please see our [Contributing Guide](docs/contributer_guide.md) for details.
 
 ## License
 


### PR DESCRIPTION
The previous link to Contributer Guide is directed to an empty project. This PR is for update the link to the markdown file uploaded by PR #43.