### PR TITLE
Fix FET netlist multiplier calculation bug

### DIFF
--- a/FET_MULTIPLIER_FIX.md
+++ b/FET_MULTIPLIER_FIX.md
@@ -1,0 +1,78 @@
+# FET Netlist Multiplier Fix
+
+## Problem Description
+
+There was an issue with the multiplier and finger counting in the `Fet` Netlist generation code in `/src/glayout/primitives/fet.py` around line 109. The problem occurred when using the `connect_netlist` automated netlist generation in upper-level designs.
+
+### Specific Issue
+
+In the `fet_netlist` function, the multiplication factor was incorrectly calculated as:
+
+```python
+'mult': mtop / 2,
+```
+
+Where `mtop = fingers * multipliers`.
+
+### Why This Was Wrong
+
+1. **Incorrect SPICE Parameter**: The `mult` parameter in SPICE represents the number of parallel transistors. Dividing by 2 made no electrical sense.
+
+2. **Failed LVS**: For cases like `width=3, fingers=1`, this would result in `mult=0.5`, which would cause Layout vs Schematic (LVS) verification to fail.
+
+3. **Broken Netlist Generation**: Automated netlist generation in upper-level designs would produce incorrect results.
+
+## Solution
+
+The fix was simple but critical:
+
+```python
+# BEFORE (incorrect):
+'mult': mtop / 2,
+
+# AFTER (correct):  
+'mult': mtop,
+```
+
+## Impact of the Fix
+
+### Before Fix
+- `fingers=1, multipliers=1` → `mult=0.5` ❌
+- `fingers=4, multipliers=1` → `mult=2.0` ❌ 
+- `fingers=2, multipliers=2` → `mult=2.0` ❌
+
+### After Fix
+- `fingers=1, multipliers=1` → `mult=1` ✅
+- `fingers=4, multipliers=1` → `mult=4` ✅
+- `fingers=2, multipliers=2` → `mult=4` ✅
+
+## Files Changed
+
+- `/src/glayout/primitives/fet.py` (line 109)
+
+## Testing
+
+The fix has been verified through:
+
+1. **Code inspection**: Confirmed the incorrect division has been removed
+2. **Parameter calculation**: Verified correct `mult` values for various finger/multiplier combinations
+3. **User case simulation**: Confirmed the specific problem case (`width=3, fingers=1`) now works correctly
+
+## Benefits
+
+✅ **LVS Verification**: Layout vs Schematic checks now pass correctly  
+✅ **SPICE Simulation**: Correct device sizing in simulations  
+✅ **Automated Netlist Generation**: Proper netlist generation for upper-level designs  
+✅ **Design Reliability**: Consistent and correct electrical behavior  
+
+## User's Original Problem
+
+The user's example with `width=3, fingers=1` was failing because:
+- Old code: `mult = (1 * 1) / 2 = 0.5` (invalid)
+- New code: `mult = (1 * 1) = 1` (correct)
+
+The user's diff_pair example should now work correctly with the LVS verification passing.
+
+---
+
+**Note**: This fix affects all FET devices (NMOS and PMOS) generated through the gLayout library, ensuring consistent and correct netlist generation across all designs.

--- a/src/glayout/primitives/fet.py
+++ b/src/glayout/primitives/fet.py
@@ -106,7 +106,7 @@ XMAIN   D G S B {model} l={{l}} w={{w}} m={{m}}"""
             'model': model,
             'length': ltop,
             'width': wtop,
-            'mult': mtop / 2,
+            'mult': mtop,
             'dummy_mult': dmtop
         }
     )


### PR DESCRIPTION
## Problem

The fet_netlist function in src/glayout/primitives/fet.py contains an incorrect calculation for the transistor multiplier parameter that causes LVS verification failures and incorrect SPICE netlist generation.

## Root Cause

Line 109 in fet_netlist function incorrectly divides the multiplier by 2:
```python
'mult': mtop / 2,  # Incorrect
```

Where `mtop = fingers * multipliers`

## Impact

- LVS verification fails for single-finger transistors (e.g., width=3, fingers=1)
- Automated netlist generation produces incorrect SPICE parameters
- Upper-level design integration broken for certain transistor configurations

## Solution

Remove the erroneous division by 2:
```python
'mult': mtop,  # Correct
```

## Verification

Test cases demonstrate the fix:
- fingers=1, multipliers=1: mult=0.5 (before) → mult=1 (after)
- fingers=4, multipliers=1: mult=2.0 (before) → mult=4 (after)
- fingers=2, multipliers=2: mult=2.0 (before) → mult=4 (after)

## Files Modified

- `src/glayout/primitives/fet.py`: Core multiplier calculation fix
- `FET_MULTIPLIER_FIX.md`: Technical documentation of the issue and resolution

This change ensures correct SPICE netlist generation and resolves LVS verification failures in automated design flows.