### PR TITLE
Mimcap optionB implemented for gf180mcuD process

### DIFF
--- a/src/glayout/pdk/gf180_mapped/gf180_grules.py
+++ b/src/glayout/pdk/gf180_mapped/gf180_grules.py
@@ -307,7 +307,7 @@ grulesobj["met4"]["via3"] = {}
 grulesobj["met4"]["met4"] = {'min_width': 0.28, 'min_separation': 0.3}
 grulesobj["met4"]["via4"] = {'min_enclosure': 0.12}
 grulesobj["met4"]["met5"] = {}
-grulesobj["met4"]["capmet"] = {}
+grulesobj["met4"]["capmet"] = {'min_enclosure': 0.6}
 grulesobj["via4"]["dnwell"] = {}
 grulesobj["via4"]["pwell"] = {}
 grulesobj["via4"]["nwell"] = {}
@@ -364,5 +364,5 @@ grulesobj["capmet"]["via3"] = {}
 grulesobj["capmet"]["met4"] = {}
 grulesobj["capmet"]["via4"] = {}
 grulesobj["capmet"]["met5"] = {}
-grulesobj["capmet"]["capmet"] = {'capmettop': (42, 0), 'capmetbottom': (36, 0), 'min_separation': 1.2}
+grulesobj["capmet"]["capmet"] = {'capmettop': (81, 0), 'capmetbottom': (46, 0), 'min_separation': 1.2}
 

--- a/src/glayout/pdk/gf180_mapped/gf180_mapped.py
+++ b/src/glayout/pdk/gf180_mapped/gf180_mapped.py
@@ -30,6 +30,8 @@ LAYER = {
     "lvpwell": (204, 0),
     "dnwell": (12, 0),
     "CAP_MK": (117, 5),
+    "MIM_L_MK": (117, 10),
+    "fusetop": (75, 0),
     # _Label Layer Definations
     "metal5_label": (81,10),
     "metal4_label": (46,10),
@@ -78,7 +80,7 @@ gf180_glayer_mapping = {
     "active_diff_label": "comp_label",
 }
 
-# note for DRC, there is mim_option 'A'. This is the one configured for use
+# note for DRC, there is mim_option 'B'. This is the one configured for use
 
 gf180_lydrc_file_path = Path(__file__).resolve().parent / "gf180mcu_drc.lydrc"
 # openfasoc_dir = Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent

--- a/src/glayout/primitives/mimcap.py
+++ b/src/glayout/primitives/mimcap.py
@@ -137,8 +137,9 @@ def mimcap(
     )
     
     # 3. Create top metal plate with via connections
+    # Use minus1=False to get maximum via coverage like KLayout generator
     top_met_ref = mim_cap << via_array(
-        pdk, capmetbottom, capmettop, size=size, minus1=True, lay_bottom=False
+        pdk, capmetbottom, capmettop, size=size, minus1=False, lay_bottom=False
     )
     
     # 4. Add FuseTop layer - required for both options (defines the MIM area)


### PR DESCRIPTION
This PR is a continuation of @LuighiV's PR#54. It adds support for the option-B MiM capacitor in the gf180mcuD process. 

The layout is extracted as ```cap_mim_2f0_m4m5_noshield```. 

DRC clean with drc(full) ,  ```Magic VLSI v.8.3.489```, ciel version of ```gf180mcu: 4d004a98790dbffee2f4c725606ca580495921b4 (2025.09.02) ```

Added initial support for option A, but it is not yet complete. If no option is given to mimcap() call, the default choice is option B

For future work, we need to:
-  add proper layers for sky130 (and ihp130), so that the mimcap routine works in other PDKs as well. 
- for the other flavors of gf180mcu (fewer metal layers), need to change topmet and topmet-1 (for version D that is metal5 and metal4)