### PR TITLE
docs: Add comments explaining MIMCAP Option A/B redundancy

### DIFF
--- a/src/glayout/pdk/gf180_mapped/gf180_mapped.py
+++ b/src/glayout/pdk/gf180_mapped/gf180_mapped.py
@@ -78,7 +78,11 @@ gf180_glayer_mapping = {
     "active_diff_label": "comp_label",
 }
 
-# note for DRC, there is mim_option 'A'. This is the one configured for use
+# NOTE: MIMCAP configuration - there are two options (A and B) with redundant DRC rules
+# Option A: Uses metal2-metal3 (original implementation)
+# Option B: Uses metal4-metal5 (added in PR#54 continuation for gf180mcuD)
+# Both options have duplicate DRC rules but different metal layers
+# Default behavior varies by process variant - see gf180mcu_drc.lydrc for variant-specific settings
 
 gf180_lydrc_file_path = Path(__file__).resolve().parent / "gf180mcu_drc.lydrc"
 # openfasoc_dir = Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent

--- a/src/glayout/pdk/gf180_mapped/gf180mcu.drc
+++ b/src/glayout/pdk/gf180_mapped/gf180mcu.drc
@@ -3462,6 +3462,11 @@ hres_poly.forget
 #================================================
 #------------MIM CAPACITOR OPTION A -------------
 #================================================
+# NOTE: This section implements MIM capacitor Option A (metal2-metal3 based)
+# This was the original implementation before Option B was added
+# Both options share similar DRC rules but use different metal layers
+# Option A: Uses metal2 (bottom) + via2 + fusetop (top)
+# Related to PR that changed mimcap from A to B - see Option B section below
 
 if MIM_OPTION == "A"
 logger.info("MIM Capacitor Option A section")
@@ -3571,6 +3576,13 @@ mim11_large_metal2_violation.forget
 #================================================
 #-------------MIM CAPACITOR OPTION B-------------
 #================================================
+# NOTE: This section implements MIM capacitor Option B (metal4-metal5 based)
+# This was added as continuation of @LuighiV's PR#54 for gf180mcuD process
+# Both Option A and B have redundant/duplicate DRC rules - they follow same pattern
+# but use different metal layers:
+# Option B: Uses topmin1_metal (metal4) + top_via (via4) + fusetop (top)
+# Rules MIMTM.1-MIMTM.11 mirror MIM.1-MIM.11 but with different metal layers
+# This creates redundancy but allows different process variants to use appropriate metal stack
 
 elsif MIM_OPTION == "B"
 logger.info("MIM Capacitor Option B section")

--- a/src/glayout/pdk/gf180_mapped/gf180mcu_drc.lydrc
+++ b/src/glayout/pdk/gf180_mapped/gf180mcu_drc.lydrc
@@ -65,22 +65,25 @@ drc_res = `#{cmd}`
 ## pass options to main.drc
 $run_mode = options["run_mode"]
 
+# NOTE: MIMCAP option configuration for different gf180mcu variants
+# Both Option A and B have redundant DRC rules but use different metal layers
+# This creates duplication but allows process-specific metal stack usage
 if options["variant"] == "A" 
   $metal_top = "30K"
   $metal_level = "3LM"
-  $mim_option = "A"
+  $mim_option = "A"  # Uses metal2-metal3
 elsif options["variant"] == "B"
   $metal_top = "11K"
   $metal_level = "4LM"
-  $mim_option = "B"
+  $mim_option = "B"  # Uses metal3-metal4
 elsif options["variant"] == "C"
   $metal_top = "9K"
   $metal_level = "5LM"
-  $mim_option = "B"
+  $mim_option = "B"  # Uses metal4-metal5
 elsif options["variant"] == "D"
   $metal_top = "11K"
   $metal_level = "5LM"
-  $mim_option = "B"
+  $mim_option = "B"  # Uses metal4-metal5 (gf180mcuD - PR#54 continuation)
 end
 
 $topcell = options["top_cell_name"]

--- a/src/glayout/primitives/mimcap.py
+++ b/src/glayout/primitives/mimcap.py
@@ -15,6 +15,12 @@ from glayout.spice import Netlist
 def __get_mimcap_layerconstruction_info(pdk: MappedPDK) -> tuple[str,str]:
 	"""returns the glayer metal below and glayer metal above capmet
 	args: pdk
+	
+	NOTE: This function determines metal layers based on PDK configuration.
+	For gf180mcu, there are two MIMCAP options (A and B) with redundant implementations:
+	- Option A: metal2-metal3 (original)
+	- Option B: metal4-metal5 (added in PR#54 continuation)
+	The actual metal layers used depend on the PDK's grules configuration.
 	"""
 	capmettop = pdk.layer_to_glayer(pdk.get_grule("capmet")["capmettop"])
 	capmetbottom = pdk.layer_to_glayer(pdk.get_grule("capmet")["capmetbottom"])


### PR DESCRIPTION
This PR adds documentation comments to clarify the relationship between MIMCAP Option A and Option B implementations, addressing concerns about redundant code.
@amisapta15 Can you please review?