### PR TITLE
Detaching Backend for Better Performance

### DIFF
--- a/src/glayout/backend/__init__.py
+++ b/src/glayout/backend/__init__.py
@@ -1,0 +1,75 @@
+"""Layout backend selector.
+
+All glayout code imports layout primitives from this package instead of
+reaching into gdsfactory directly. That gives a single switch — set by the
+`GLAYOUT_BACKEND` env var or `set_backend(...)` — between:
+
+  - "gdsfactory" (default): thin passthrough to gdsfactory. Preserves
+    existing behavior so the repo keeps working unchanged.
+  - "gdstk": native gdstk implementation. Faster; intended to be the
+    eventual default.
+
+Only symbols gLayout actually uses are exposed. Both backends present the
+same surface.
+"""
+import os
+
+_VALID = ("gdsfactory", "gdstk")
+_backend = os.environ.get("GLAYOUT_BACKEND", "gdsfactory").lower().strip()
+
+_EXPORTS = (
+    "Component",
+    "ComponentReference",
+    "Port",
+    "Polygon",
+    "Layer",
+    "PathType",
+    "Pdk",
+    "ComponentOrReference",
+    "snap_to_grid",
+    "cell",
+    "clear_cache",
+    "copy",
+    "rectangle",
+    "rectangular_ring",
+    "boolean",
+    "import_gds",
+    "transformed",
+    "route_quad",
+)
+
+
+def _load(name: str):
+    if name == "gdstk":
+        from . import _gdstk as mod
+    elif name == "gdsfactory":
+        from . import _gdsfactory as mod
+    else:
+        raise ValueError(f"unknown GLAYOUT_BACKEND={name!r}; valid: {_VALID}")
+    return mod
+
+
+def _bind(mod) -> None:
+    g = globals()
+    for name in _EXPORTS:
+        g[name] = getattr(mod, name)
+
+
+def get_backend() -> str:
+    return _backend
+
+
+def set_backend(name: str) -> None:
+    """Switch backend at runtime. Rebinds the module-level names for callers
+    that do `from glayout.backend import X` AFTER this call."""
+    global _backend
+    name = name.lower().strip()
+    if name not in _VALID:
+        raise ValueError(f"unknown backend {name!r}; valid: {_VALID}")
+    _backend = name
+    _bind(_load(name))
+
+
+_bind(_load(_backend))
+
+__all__ = (*_EXPORTS, "get_backend", "set_backend")

--- a/src/glayout/backend/_gdsfactory.py
+++ b/src/glayout/backend/_gdsfactory.py
@@ -1,0 +1,47 @@
+"""gdsfactory passthrough backend.
+
+Re-exports the gdsfactory symbols the rest of glayout depends on, under the
+same names the gdstk backend uses. This keeps `from glayout.backend import X`
+working identically regardless of which backend is active.
+"""
+from gdsfactory.component import Component, copy
+from gdsfactory.component_reference import ComponentReference
+from gdsfactory.port import Port
+from gdsfactory.polygon import Polygon
+from gdsfactory.cell import cell, clear_cache
+from gdsfactory.components.rectangle import rectangle
+from gdsfactory.components.rectangular_ring import rectangular_ring
+from gdsfactory.snap import snap_to_grid
+from gdsfactory.functions import transformed
+from gdsfactory.geometry.boolean import boolean
+from gdsfactory.read.import_gds import import_gds
+from gdsfactory.routing.route_quad import route_quad
+from gdsfactory.typings import Layer, ComponentOrReference, PathType
+
+# Pdk lives in a separate module in newer gdsfactory
+try:
+    from gdsfactory.pdk import Pdk
+except Exception:  # pragma: no cover
+    from typing import Any as Pdk  # type: ignore
+
+
+__all__ = [
+    "Component",
+    "ComponentReference",
+    "Port",
+    "Polygon",
+    "Layer",
+    "PathType",
+    "Pdk",
+    "ComponentOrReference",
+    "snap_to_grid",
+    "cell",
+    "clear_cache",
+    "copy",
+    "rectangle",
+    "rectangular_ring",
+    "boolean",
+    "import_gds",
+    "transformed",
+    "route_quad",
+]

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -264,6 +264,8 @@ class ComponentReference:
         self._ref = gref
         # owner is the Component this reference has been added to (not the target)
         self.owner: Optional["Component"] = None
+        # `info` is used by some cells to attach netlist / hierarchy metadata.
+        self.info: dict = {}
 
     # --- transform properties ---------------------------------------------
     @property

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -1,0 +1,1094 @@
+"""Native gdstk implementation of glayout's Component, ComponentReference, and Port.
+
+Designed as a drop-in replacement for the corresponding gdsfactory types
+(as used inside this repo). Coverage focuses on the API surface actually
+exercised by gLayout — not full gdsfactory parity.
+"""
+from __future__ import annotations
+
+import itertools
+import math
+import os
+from pathlib import Path as _Path
+from typing import Any, Callable, Iterable, Optional, Sequence, Union
+
+import gdstk
+
+# ---------------------------------------------------------------------------
+# Type aliases (gdsfactory.typings shims)
+# ---------------------------------------------------------------------------
+
+Layer = tuple[int, int]
+Coord = tuple[float, float]
+PathType = Union[str, _Path]
+
+
+# --- Pdk (minimal pydantic BaseModel replacement for gdsfactory.pdk.Pdk) ---
+# MappedPDK inherits from this, so we match enough of the gdsfactory shape for
+# MappedPDK to work (name, layers, default_decorator, gds_write_settings,
+# cell_decorator_settings, .activate()). Extra fields are allowed so callers
+# can pass arbitrary pdk-specific config.
+from pydantic import BaseModel, ConfigDict  # noqa: E402
+
+
+class _GdsWriteSettings(BaseModel):
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+    precision: float = 1e-9
+    unit: float = 1e-6
+    flatten_invalid_refs: bool = False
+
+
+class _CellDecoratorSettings(BaseModel):
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+    cache: bool = False
+
+
+class Pdk(BaseModel):
+    """Minimal shim for gdsfactory.pdk.Pdk. Holds enough state for
+    MappedPDK to function."""
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+    name: str
+    layers: Optional[dict] = None
+    default_decorator: Optional[Any] = None
+    grid_size: float = 0.001  # microns; matches gdsfactory default
+    gds_write_settings: _GdsWriteSettings = _GdsWriteSettings()
+    cell_decorator_settings: _CellDecoratorSettings = _CellDecoratorSettings()
+
+    def activate(self) -> None:
+        """No-op. gdsfactory's activate() registered the PDK in a global
+        registry; that registry is a gdsfactory concern and isn't needed
+        once gdsfactory is out of the import graph."""
+        return None
+
+    def validate_layers(self, layers_required) -> None:
+        """Mimics gdsfactory.pdk.Pdk.validate_layers — raise if any named
+        layer isn't in `self.layers`."""
+        if self.layers is None:
+            return
+        for lay in layers_required:
+            if lay not in self.layers:
+                raise ValueError(f"layer {lay!r} not in pdk.layers")
+
+    def get_layer(self, layer_name: str):
+        """Return the (layer, datatype) tuple for a named layer."""
+        if self.layers is None:
+            raise ValueError("pdk.layers is not set")
+        if layer_name not in self.layers:
+            raise ValueError(f"layer {layer_name!r} not in pdk.layers")
+        return self.layers[layer_name]
+
+
+# ---------------------------------------------------------------------------
+# Port
+# ---------------------------------------------------------------------------
+
+
+def _pydantic_instance_schema(cls):
+    """pydantic v2 hook: treat the class as an opaque type (isinstance check)."""
+    try:
+        from pydantic_core import core_schema
+    except ImportError:  # pragma: no cover
+        return None
+    return core_schema.is_instance_schema(cls)
+
+
+class Port:
+    """Lightweight mutable port.
+
+    Mirrors the fields gLayout reads/writes on `gdsfactory.port.Port`.
+    Positional args match gdsfactory's positional order used in this repo:
+    `Port(name, orientation, center, width, layer=..., ...)`.
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        return _pydantic_instance_schema(cls)
+
+
+    __slots__ = (
+        "name",
+        "orientation",
+        "_center",
+        "width",
+        "layer",
+        "port_type",
+        "parent",
+        "cross_section",
+        "shear_angle",
+    )
+
+    @property
+    def center(self) -> Coord:
+        return self._center
+
+    @center.setter
+    def center(self, value: Coord) -> None:
+        self._center = (float(value[0]), float(value[1]))
+
+    @property
+    def x(self) -> float:
+        return self._center[0]
+
+    @x.setter
+    def x(self, value: float) -> None:
+        self._center = (float(value), self._center[1])
+
+    @property
+    def y(self) -> float:
+        return self._center[1]
+
+    @y.setter
+    def y(self, value: float) -> None:
+        self._center = (self._center[0], float(value))
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        orientation: float = 0.0,
+        center: Coord = (0.0, 0.0),
+        width: float = 0.0,
+        layer: Optional[Layer] = None,
+        port_type: str = "electrical",
+        parent: Optional["Component"] = None,
+        cross_section=None,
+        shear_angle: Optional[float] = None,
+    ):
+        self.name = name
+        self.orientation = float(orientation) if orientation is not None else 0.0
+        self._center = (float(center[0]), float(center[1]))
+        self.width = float(width)
+        self.layer = tuple(layer) if layer is not None else None
+        self.port_type = port_type
+        self.parent = parent
+        self.cross_section = cross_section
+        self.shear_angle = shear_angle
+
+    def __repr__(self) -> str:
+        return (
+            f"Port(name={self.name!r}, center={self.center}, "
+            f"orientation={self.orientation}, width={self.width}, layer={self.layer})"
+        )
+
+    def copy(self, name: Optional[str] = None) -> "Port":
+        return Port(
+            name=name if name is not None else self.name,
+            orientation=self.orientation,
+            center=self.center,
+            width=self.width,
+            layer=self.layer,
+            port_type=self.port_type,
+            parent=self.parent,
+            cross_section=self.cross_section,
+            shear_angle=self.shear_angle,
+        )
+
+    def move_copy(self, offset: Coord) -> "Port":
+        c = self.copy()
+        c._center = (c._center[0] + float(offset[0]), c._center[1] + float(offset[1]))
+        return c
+
+
+def _apply_transform_to_port(
+    port: Port,
+    origin: Coord,
+    rotation_deg: float,
+    x_reflection: bool,
+) -> Port:
+    """Return a copy of `port` with the GDS reference transform applied.
+
+    GDS convention: x_reflection first (y -> -y), then rotation, then translation.
+    """
+    p = port.copy()
+    x, y = p._center
+    o = p.orientation
+    if x_reflection:
+        y = -y
+        o = -o
+    if rotation_deg:
+        rad = math.radians(rotation_deg)
+        cs, sn = math.cos(rad), math.sin(rad)
+        x, y = x * cs - y * sn, x * sn + y * cs
+        o += rotation_deg
+    x += origin[0]
+    y += origin[1]
+    p._center = (x, y)
+    p.orientation = o % 360.0
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_name_counter = itertools.count()
+
+
+def _unique_name(prefix: str = "Component") -> str:
+    return f"{prefix}_{next(_name_counter)}"
+
+
+def _bbox_or_zero(bbox) -> tuple[Coord, Coord]:
+    if bbox is None:
+        return ((0.0, 0.0), (0.0, 0.0))
+    (x0, y0), (x1, y1) = bbox
+    return ((float(x0), float(y0)), (float(x1), float(y1)))
+
+
+def _as_layer(layer) -> Layer:
+    if layer is None:
+        raise ValueError("layer is required")
+    return (int(layer[0]), int(layer[1]))
+
+
+# ---------------------------------------------------------------------------
+# ComponentReference
+# ---------------------------------------------------------------------------
+
+
+class ComponentReference:
+    """Wraps a `gdstk.Reference`. Exposes transform mutation and transformed
+    views of the parent component's ports/bbox."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        return _pydantic_instance_schema(cls)
+
+
+    def __init__(self, parent: "Component", gref: Optional[gdstk.Reference] = None):
+        self.parent = parent
+        if gref is None:
+            gref = gdstk.Reference(parent._cell, origin=(0.0, 0.0))
+        self._ref = gref
+        # owner is the Component this reference has been added to (not the target)
+        self.owner: Optional["Component"] = None
+
+    # --- transform properties ---------------------------------------------
+    @property
+    def origin(self) -> Coord:
+        return tuple(self._ref.origin)  # type: ignore[return-value]
+
+    @origin.setter
+    def origin(self, value: Coord) -> None:
+        self._ref.origin = (float(value[0]), float(value[1]))
+
+    @property
+    def rotation(self) -> float:
+        # gdstk stores rotation in radians
+        return math.degrees(self._ref.rotation)
+
+    @rotation.setter
+    def rotation(self, value_deg: float) -> None:
+        self._ref.rotation = math.radians(float(value_deg))
+
+    @property
+    def x_reflection(self) -> bool:
+        return bool(self._ref.x_reflection)
+
+    @x_reflection.setter
+    def x_reflection(self, value: bool) -> None:
+        self._ref.x_reflection = bool(value)
+
+    # --- movement (mutate + return self) ----------------------------------
+    def movex(self, dx: float = 0.0) -> "ComponentReference":
+        ox, oy = self.origin
+        self.origin = (ox + float(dx), oy)
+        return self
+
+    def movey(self, dy: float = 0.0) -> "ComponentReference":
+        ox, oy = self.origin
+        self.origin = (ox, oy + float(dy))
+        return self
+
+    def move(
+        self,
+        origin: Optional[Coord] = None,
+        destination: Optional[Coord] = None,
+    ) -> "ComponentReference":
+        """Move this reference. Two calling conventions:
+          - move((dx, dy))                    — translate by offset
+          - move(destination=(x, y))          — move so the ref's center lands at (x, y)
+          - move(origin=(x0, y0),
+                 destination=(x1, y1))        — translate by (x1-x0, y1-y0)
+        """
+        if destination is None and origin is not None and not isinstance(origin, ComponentReference):
+            # single-arg form: treat as offset
+            return self.movex(origin[0]).movey(origin[1])
+        if destination is None:
+            return self
+        if origin is None:
+            # move by (destination - current center)
+            cx, cy = self.center
+            dx, dy = destination[0] - cx, destination[1] - cy
+        else:
+            dx, dy = destination[0] - origin[0], destination[1] - origin[1]
+        return self.movex(dx).movey(dy)
+
+    def rotate(self, angle_deg: float, center: Coord = (0.0, 0.0)) -> "ComponentReference":
+        # rotate the reference's placement about `center`
+        ox, oy = self.origin
+        cx, cy = center
+        rad = math.radians(float(angle_deg))
+        cs, sn = math.cos(rad), math.sin(rad)
+        dx, dy = ox - cx, oy - cy
+        self.origin = (cx + dx * cs - dy * sn, cy + dx * sn + dy * cs)
+        self.rotation = self.rotation + float(angle_deg)
+        return self
+
+    def mirror_x(self, x0: float = 0.0) -> "ComponentReference":
+        """Mirror across the vertical line x=x0 (flip left-right)."""
+        return self.mirror(p1=(x0, 0.0), p2=(x0, 1.0))
+
+    def mirror_y(self, y0: float = 0.0) -> "ComponentReference":
+        """Mirror across the horizontal line y=y0 (flip top-bottom)."""
+        return self.mirror(p1=(0.0, y0), p2=(1.0, y0))
+
+    def mirror(self, p1: Coord = (0.0, 0.0), p2: Coord = (0.0, 1.0)) -> "ComponentReference":
+        """Mirror across the line through p1-p2. Limited impl: supports the
+        x-axis (horizontal) and y-axis (vertical) cases gLayout routing uses."""
+        x1, y1 = p1
+        x2, y2 = p2
+        if x1 == x2:  # vertical line: mirror across x = x1
+            self._ref.x_reflection = not self._ref.x_reflection
+            self.rotation = 180.0 - self.rotation
+            ox, oy = self.origin
+            self.origin = (2 * x1 - ox, oy)
+        elif y1 == y2:  # horizontal line: mirror across y = y1
+            self._ref.x_reflection = not self._ref.x_reflection
+            ox, oy = self.origin
+            self.origin = (ox, 2 * y1 - oy)
+        else:
+            raise NotImplementedError("mirror only supports axis-aligned lines")
+        return self
+
+    # --- views -------------------------------------------------------------
+    @property
+    def ports(self) -> dict[str, Port]:
+        origin = self.origin
+        rot = self.rotation
+        xr = self.x_reflection
+        return {
+            name: _apply_transform_to_port(p, origin, rot, xr)
+            for name, p in self.parent.ports.items()
+        }
+
+    def get_ports_list(self, prefix: str = "", **filters) -> list[Port]:
+        """Filter ports. `prefix` filters to names starting with that prefix
+        (matches gdsfactory.component.Component.get_ports_list). Extra
+        kwargs filter by attribute equality."""
+        out: list[Port] = []
+        for name, p in self.ports.items():
+            if prefix and not name.startswith(prefix):
+                continue
+            if filters:
+                skip = False
+                for k, v in filters.items():
+                    if getattr(p, k, None) != v:
+                        skip = True
+                        break
+                if skip:
+                    continue
+            out.append(p)
+        return out
+
+    @property
+    def bbox(self) -> tuple[Coord, Coord]:
+        return _bbox_or_zero(self._ref.bounding_box())
+
+    @property
+    def center(self) -> Coord:
+        (x0, y0), (x1, y1) = self.bbox
+        return ((x0 + x1) / 2.0, (y0 + y1) / 2.0)
+
+    @property
+    def xmin(self) -> float: return self.bbox[0][0]
+    @property
+    def xmax(self) -> float: return self.bbox[1][0]
+    @property
+    def ymin(self) -> float: return self.bbox[0][1]
+    @property
+    def ymax(self) -> float: return self.bbox[1][1]
+
+    @property
+    def name(self) -> str:
+        return self.parent.name
+
+    def __repr__(self) -> str:
+        return f"ComponentReference(parent={self.parent.name!r}, origin={self.origin}, rotation={self.rotation})"
+
+
+# ---------------------------------------------------------------------------
+# Component
+# ---------------------------------------------------------------------------
+
+
+class Component:
+    """Mutable layout cell backed by a `gdstk.Cell`.
+
+    Shape of the public API matches what gLayout uses from gdsfactory's
+    Component — not the entire gdsfactory surface.
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        return _pydantic_instance_schema(cls)
+
+
+    def __init__(self, name: Optional[str] = None):
+        self._cell = gdstk.Cell(name if name is not None else _unique_name())
+        self.ports: dict[str, Port] = {}
+        self._references: list[ComponentReference] = []
+        self._locked = False
+        self.info: dict = {}
+
+    # --- identity ----------------------------------------------------------
+    @property
+    def name(self) -> str:
+        return self._cell.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._cell.name = str(value)
+
+    def __repr__(self) -> str:
+        return f"Component(name={self.name!r}, ports={list(self.ports)}, refs={len(self._references)})"
+
+    # --- lock/unlock (no-op; gdsfactory compat) ---------------------------
+    def lock(self) -> "Component":
+        self._locked = True
+        return self
+
+    def unlock(self) -> "Component":
+        self._locked = False
+        return self
+
+    # --- add / << ----------------------------------------------------------
+    def add_ref(self, component: "Component", alias: Optional[str] = None) -> ComponentReference:
+        ref = component.ref()
+        self.add(ref)
+        return ref
+
+    def __lshift__(self, component: "Component") -> ComponentReference:
+        return self.add_ref(component)
+
+    def add(
+        self,
+        element: Union[ComponentReference, gdstk.Reference, gdstk.Polygon, gdstk.Label, Iterable],
+    ) -> "Component":
+        """Add a reference, polygon, label, or iterable of those."""
+        if isinstance(element, ComponentReference):
+            self._cell.add(element._ref)
+            element.owner = self
+            self._references.append(element)
+        elif isinstance(element, (gdstk.Reference, gdstk.Polygon, gdstk.Label)):
+            self._cell.add(element)
+        elif isinstance(element, Iterable):
+            for e in element:
+                self.add(e)
+        else:
+            raise TypeError(f"Component.add: unsupported type {type(element).__name__}")
+        return self
+
+    def ref(self) -> ComponentReference:
+        """Return a fresh ComponentReference pointing at this Component.
+        Not yet attached to any parent."""
+        return ComponentReference(self)
+
+    # --- ports -------------------------------------------------------------
+    def add_port(
+        self,
+        name: Optional[str] = None,
+        center: Coord = (0.0, 0.0),
+        width: float = 0.0,
+        orientation: float = 0.0,
+        layer: Optional[Layer] = None,
+        port_type: str = "electrical",
+        port: Optional[Port] = None,
+    ) -> Port:
+        if port is not None:
+            p = port.copy(name=name if name is not None else port.name)
+        else:
+            p = Port(
+                name=name,
+                orientation=orientation,
+                center=center,
+                width=width,
+                layer=layer,
+                port_type=port_type,
+                parent=self,
+            )
+        if p.name is None:
+            raise ValueError("port name is required")
+        if p.name in self.ports:
+            raise ValueError(f"duplicate port name {p.name!r} on component {self.name!r}")
+        self.ports[p.name] = p
+        return p
+
+    def add_ports(
+        self,
+        ports: Iterable[Port],
+        prefix: str = "",
+    ) -> "Component":
+        for p in ports:
+            new_name = f"{prefix}{p.name}" if prefix else p.name
+            np = p.copy(name=new_name)
+            np.parent = self
+            if new_name in self.ports:
+                raise ValueError(f"duplicate port name {new_name!r} on component {self.name!r}")
+            self.ports[new_name] = np
+        return self
+
+    def get_ports_list(self, prefix: str = "", **filters) -> list[Port]:
+        out: list[Port] = []
+        for name, p in self.ports.items():
+            if filters:
+                skip = False
+                for k, v in filters.items():
+                    if getattr(p, k, None) != v:
+                        skip = True
+                        break
+                if skip:
+                    continue
+            if prefix:
+                out.append(p.copy(name=f"{prefix}{name}"))
+            else:
+                out.append(p)
+        return out
+
+    # --- geometry ---------------------------------------------------------
+    def add_polygon(self, points, layer: Optional[Layer] = None) -> gdstk.Polygon:
+        """Add a polygon. Accepts:
+          - a gdstk.Polygon                      (layer ignored)
+          - an iterable of gdstk.Polygon         (layer ignored)
+          - a list of (x,y) points + a layer=(l,dt)
+        """
+        if isinstance(points, gdstk.Polygon):
+            self._cell.add(points)
+            return points
+        if isinstance(points, (list, tuple)) and points and isinstance(points[0], gdstk.Polygon):
+            for p in points:
+                self._cell.add(p)
+            return points[0]
+        l, dt = _as_layer(layer)
+        poly = gdstk.Polygon(list(points), layer=l, datatype=dt)
+        self._cell.add(poly)
+        return poly
+
+    def add_padding(
+        self,
+        layers: Sequence[Layer] = (),
+        default: float = 0.0,
+        top: Optional[float] = None,
+        bottom: Optional[float] = None,
+        left: Optional[float] = None,
+        right: Optional[float] = None,
+    ) -> "Component":
+        """Add a background rectangle on each layer in `layers`, padded around
+        the current bbox. Matches gdsfactory.add_padding.add_padding semantics
+        used in this repo."""
+        (x0, y0), (x1, y1) = self.bbox
+        t = top if top is not None else default
+        b = bottom if bottom is not None else default
+        l = left if left is not None else default
+        r = right if right is not None else default
+        for layer in layers:
+            ll, dt = int(layer[0]), int(layer[1])
+            self._cell.add(gdstk.rectangle((x0 - l, y0 - b),
+                                           (x1 + r, y1 + t),
+                                           layer=ll, datatype=dt))
+        return self
+
+    def add_label(
+        self,
+        text: str,
+        position: Coord = (0.0, 0.0),
+        layer: Optional[Layer] = None,
+        anchor: str = "o",
+        rotation: float = 0.0,
+        magnification: float = 1.0,
+    ) -> gdstk.Label:
+        l, dt = _as_layer(layer)
+        lbl = gdstk.Label(
+            str(text),
+            (float(position[0]), float(position[1])),
+            anchor=anchor,
+            rotation=math.radians(rotation),
+            magnification=magnification,
+            layer=l,
+            texttype=dt,
+        )
+        self._cell.add(lbl)
+        return lbl
+
+    # --- bbox / center ----------------------------------------------------
+    @property
+    def bbox(self) -> tuple[Coord, Coord]:
+        return _bbox_or_zero(self._cell.bounding_box())
+
+    @property
+    def center(self) -> Coord:
+        (x0, y0), (x1, y1) = self.bbox
+        return ((x0 + x1) / 2.0, (y0 + y1) / 2.0)
+
+    @property
+    def xmin(self) -> float: return self.bbox[0][0]
+    @property
+    def xmax(self) -> float: return self.bbox[1][0]
+    @property
+    def ymin(self) -> float: return self.bbox[0][1]
+    @property
+    def ymax(self) -> float: return self.bbox[1][1]
+
+    @property
+    def size(self) -> Coord:
+        (x0, y0), (x1, y1) = self.bbox
+        return (x1 - x0, y1 - y0)
+
+    @property
+    def references(self) -> list[ComponentReference]:
+        return list(self._references)
+
+    # --- structural transforms --------------------------------------------
+    def flatten(self, single_layer: Optional[Layer] = None) -> "Component":
+        """Resolve all references into this cell's polygons/labels. Mutates."""
+        self._cell.flatten()
+        self._references.clear()
+        if single_layer is not None:
+            l, dt = _as_layer(single_layer)
+            for p in self._cell.polygons:
+                p.layer = l
+                p.datatype = dt
+        return self
+
+    def extract(self, layers: Sequence[Layer]) -> "Component":
+        """Return a new Component containing only polygons on the given layers.
+        Hierarchy is resolved (flattened) in the output."""
+        layer_set = {(int(l), int(dt)) for (l, dt) in layers}
+        new = Component(name=_unique_name(self.name + "_extract"))
+        for (l, dt) in layer_set:
+            for p in self._cell.get_polygons(layer=l, datatype=dt):
+                new._cell.add(p.copy())
+        return new
+
+    def remove_layers(self, layers: Sequence[Layer]) -> "Component":
+        """Remove all polygons on the given layers. Flattens references first
+        so polygons inside sub-cells also disappear. Mutates and returns self."""
+        layer_set = {(int(l), int(dt)) for (l, dt) in layers}
+        self.flatten()
+        keep = [p for p in self._cell.polygons if (p.layer, p.datatype) not in layer_set]
+        for p in list(self._cell.polygons):
+            self._cell.remove(p)
+        for p in keep:
+            self._cell.add(p)
+        return self
+
+    def copy(self, name: Optional[str] = None) -> "Component":
+        """Deep-copy this Component. References keep pointing at the same
+        target cells (same semantics as gdsfactory's Component.copy)."""
+        new_name = name if name is not None else _unique_name(self.name + "_copy")
+        new = Component.__new__(Component)
+        new._cell = self._cell.copy(new_name, deep_copy=False)
+        new._locked = False
+        new.info = dict(self.info)
+        # ports
+        new.ports = {}
+        for pname, p in self.ports.items():
+            pc = p.copy()
+            pc.parent = new
+            new.ports[pname] = pc
+        # references: rebuild wrappers around the copied cell's refs
+        new._references = []
+        for src_ref, new_gref in zip(self._references, new._cell.references):
+            wrapper = ComponentReference(src_ref.parent, new_gref)
+            wrapper.owner = new
+            new._references.append(wrapper)
+        return new
+
+    # --- GDS I/O ----------------------------------------------------------
+    def _collect_cells(self) -> list[gdstk.Cell]:
+        """Depth-first collect this cell + all cells reachable via references,
+        uniqued by identity, with referenced cells before their users."""
+        seen: dict[int, gdstk.Cell] = {}
+        order: list[gdstk.Cell] = []
+
+        def visit(cell: gdstk.Cell) -> None:
+            if id(cell) in seen:
+                return
+            seen[id(cell)] = cell
+            for r in cell.references:
+                visit(r.cell)
+            order.append(cell)
+
+        visit(self._cell)
+        return order
+
+    def write_gds(self, filename: str, unit: float = 1e-6, precision: float = 1e-9) -> str:
+        lib = gdstk.Library(unit=unit, precision=precision)
+        used_names: set[str] = set()
+        for cell in self._collect_cells():
+            # avoid same-name collisions within the library
+            if cell.name in used_names:
+                cell.name = _unique_name(cell.name)
+            used_names.add(cell.name)
+            lib.add(cell)
+        lib.write_gds(str(filename))
+        return str(filename)
+
+
+# ---------------------------------------------------------------------------
+# ComponentOrReference type alias (after Component/CR are defined)
+# ---------------------------------------------------------------------------
+
+ComponentOrReference = Union[Component, ComponentReference]
+
+
+# ---------------------------------------------------------------------------
+# Polygon — gdstk.Polygon with a couple of gdsfactory-style accessors
+# ---------------------------------------------------------------------------
+
+
+def _normalize_layer(layer, datatype=None) -> tuple[int, int]:
+    if datatype is not None:
+        return int(layer), int(datatype)
+    if isinstance(layer, tuple) and len(layer) == 2:
+        return int(layer[0]), int(layer[1])
+    return int(layer), 0
+
+
+def Polygon(points, layer=(0, 0), datatype=None) -> gdstk.Polygon:
+    """Build a gdstk.Polygon from (points, layer=(l,dt))."""
+    l, dt = _normalize_layer(layer, datatype)
+    return gdstk.Polygon(list(points), l, dt)
+
+
+# ---------------------------------------------------------------------------
+# snap_to_grid
+# ---------------------------------------------------------------------------
+
+
+def snap_to_grid(x, nm: int = 1):
+    """Snap `x` (in micrometers) to an `nm`-nanometer grid.
+
+    Matches gdsfactory.snap.snap_to_grid semantics used in this repo.
+    Accepts scalars or iterables.
+    """
+    if x is None:
+        return None
+    if isinstance(x, (list, tuple)):
+        return type(x)(snap_to_grid(v, nm) for v in x)
+    return round(float(x) * 1000.0 / nm) * nm / 1000.0
+
+
+# ---------------------------------------------------------------------------
+# @cell decorator + clear_cache (no-ops; caching was a gdsfactory concern)
+# ---------------------------------------------------------------------------
+
+
+def cell(func: Optional[Callable] = None, **_kwargs):
+    """Pass-through cell decorator. gdsfactory's `@cell` cached by args and
+    named the Component after the function — we don't need either: Component
+    names are auto-generated for uniqueness on write, and caching introduces
+    subtle aliasing bugs (shared mutable state across calls)."""
+    if func is None:
+        return lambda f: f
+    return func
+
+
+def clear_cache() -> None:
+    """No-op; kept for API compatibility with gdsfactory."""
+    return None
+
+
+def copy(component: "Component") -> "Component":
+    """Drop-in for `gdsfactory.component.copy`."""
+    return component.copy()
+
+
+# ---------------------------------------------------------------------------
+# rectangle + rectangular_ring + primitive_rectangle
+# ---------------------------------------------------------------------------
+
+
+def _add_edge_ports(
+    comp: "Component",
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    layer: Layer,
+) -> None:
+    """Add e1 (W), e2 (N), e3 (E), e4 (S) ports on the edges of the rect."""
+    w = x1 - x0
+    h = y1 - y0
+    comp.add_port(name="e1", center=(x0, (y0 + y1) / 2.0),
+                  orientation=180, width=h, layer=layer, port_type="electrical")
+    comp.add_port(name="e2", center=((x0 + x1) / 2.0, y1),
+                  orientation=90, width=w, layer=layer, port_type="electrical")
+    comp.add_port(name="e3", center=(x1, (y0 + y1) / 2.0),
+                  orientation=0, width=h, layer=layer, port_type="electrical")
+    comp.add_port(name="e4", center=((x0 + x1) / 2.0, y0),
+                  orientation=270, width=w, layer=layer, port_type="electrical")
+
+
+def rectangle(
+    size: tuple[float, float] = (4.0, 2.0),
+    layer: Layer = (0, 0),
+    centered: bool = False,
+    port_type: str = "electrical",
+    port_orientations: Optional[tuple] = None,
+) -> "Component":
+    """Rectangle Component with 4 edge ports (e1/e2/e3/e4 = W/N/E/S)."""
+    w, h = float(size[0]), float(size[1])
+    if centered:
+        x0, y0, x1, y1 = -w / 2.0, -h / 2.0, w / 2.0, h / 2.0
+    else:
+        x0, y0, x1, y1 = 0.0, 0.0, w, h
+    c = Component(_unique_name("rectangle"))
+    c.add_polygon(gdstk.rectangle((x0, y0), (x1, y1),
+                                  layer=int(layer[0]), datatype=int(layer[1])))
+    _add_edge_ports(c, x0, y0, x1, y1, layer)
+    return c
+
+
+def rectangular_ring(
+    enclosed_size: tuple[float, float] = (4.0, 2.0),
+    width: float = 0.5,
+    layer: Layer = (0, 0),
+    centered: bool = True,
+) -> "Component":
+    """Frame/ring Component. `enclosed_size` is the inner empty region;
+    `width` is the frame thickness on each side."""
+    iw, ih = float(enclosed_size[0]), float(enclosed_size[1])
+    w = float(width)
+    ow, oh = iw + 2 * w, ih + 2 * w
+    if centered:
+        ox0, oy0 = -ow / 2.0, -oh / 2.0
+    else:
+        ox0, oy0 = 0.0, 0.0
+    ox1, oy1 = ox0 + ow, oy0 + oh
+    ix0, iy0 = ox0 + w, oy0 + w
+    ix1, iy1 = ix0 + iw, iy0 + ih
+
+    l, dt = int(layer[0]), int(layer[1])
+    outer = gdstk.rectangle((ox0, oy0), (ox1, oy1), layer=l, datatype=dt)
+    inner = gdstk.rectangle((ix0, iy0), (ix1, iy1), layer=l, datatype=dt)
+    diff = gdstk.boolean(outer, inner, "not", layer=l, datatype=dt)
+
+    c = Component(_unique_name("rectangular_ring"))
+    for p in diff:
+        c._cell.add(p)
+    _add_edge_ports(c, ox0, oy0, ox1, oy1, layer)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# boolean
+# ---------------------------------------------------------------------------
+
+
+def _as_polygon_list(obj) -> list[gdstk.Polygon]:
+    if isinstance(obj, Component):
+        return list(obj._cell.get_polygons())
+    if isinstance(obj, ComponentReference):
+        # resolve the reference's transform by baking in
+        return list(obj._ref.get_polygons())
+    if isinstance(obj, gdstk.Polygon):
+        return [obj]
+    if isinstance(obj, Iterable):
+        out: list[gdstk.Polygon] = []
+        for x in obj:
+            out.extend(_as_polygon_list(x))
+        return out
+    raise TypeError(f"boolean: unsupported operand type {type(obj).__name__}")
+
+
+def boolean(
+    A=None,
+    B=None,
+    operation: str = "or",
+    layer: Layer = (0, 0),
+    **kwargs,
+) -> "Component":
+    """Boolean of A and B.
+
+    Supports operations used in this repo: 'and', 'or', 'xor', 'not', 'A-B'.
+    Accepts Component, ComponentReference, gdstk.Polygon, or iterables.
+    """
+    # gdsfactory-style keyword args
+    if "A" in kwargs and A is None:
+        A = kwargs["A"]
+    if "B" in kwargs and B is None:
+        B = kwargs["B"]
+
+    op = operation.lower().strip()
+    if op == "a-b":
+        op = "not"
+    if op not in ("and", "or", "xor", "not"):
+        raise ValueError(f"boolean: unsupported operation {operation!r}")
+
+    polys_a = _as_polygon_list(A)
+    polys_b = _as_polygon_list(B) if B is not None else []
+    l, dt = int(layer[0]), int(layer[1])
+    result = gdstk.boolean(polys_a, polys_b, op, layer=l, datatype=dt)
+
+    c = Component(_unique_name("boolean"))
+    for p in result:
+        c._cell.add(p)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# import_gds
+# ---------------------------------------------------------------------------
+
+
+def import_gds(
+    gdspath: PathType,
+    cellname: Optional[str] = None,
+    **_kwargs,
+) -> "Component":
+    """Read `gdspath` and return its top cell (or the named cell) as a Component."""
+    lib = gdstk.read_gds(str(gdspath))
+    cells = {c.name: c for c in lib.cells}
+    if cellname is not None:
+        if cellname not in cells:
+            raise KeyError(f"cell {cellname!r} not in {gdspath}")
+        src = cells[cellname]
+    else:
+        # top cells = cells not referenced by any other cell
+        referenced: set[str] = set()
+        for c in lib.cells:
+            for r in c.references:
+                referenced.add(r.cell.name)
+        tops = [c for c in lib.cells if c.name not in referenced]
+        if not tops:
+            raise ValueError(f"no top cell in {gdspath}")
+        src = tops[0]
+
+    # Wrap the gdstk.Cell in a Component without copying.
+    wrapped = Component.__new__(Component)
+    wrapped._cell = src
+    wrapped.ports = {}
+    wrapped._references = []
+    for gref in src.references:
+        # find target cell
+        target = Component.__new__(Component)
+        target._cell = gref.cell
+        target.ports = {}
+        target._references = []
+        target._locked = False
+        target.info = {}
+        wrapper = ComponentReference(target, gref)
+        wrapper.owner = wrapped
+        wrapped._references.append(wrapper)
+    wrapped._locked = False
+    wrapped.info = {}
+    return wrapped
+
+
+# ---------------------------------------------------------------------------
+# transformed — bake a ComponentReference's transform into a new Component
+# ---------------------------------------------------------------------------
+
+
+def transformed(ref: "ComponentReference") -> "Component":
+    """Return a new Component whose contents are `ref.parent` flattened with
+    the reference's transform applied. Ports are transformed accordingly."""
+    if not isinstance(ref, ComponentReference):
+        raise TypeError("transformed expects a ComponentReference")
+    new = Component(_unique_name("transformed"))
+    # Place the ref inside a throwaway cell and flatten to bake in transforms.
+    new._cell.add(ref._ref)
+    new._cell.flatten()
+    # Transform ports
+    origin = ref.origin
+    rot = ref.rotation
+    xr = ref.x_reflection
+    for pname, p in ref.parent.ports.items():
+        tp = _apply_transform_to_port(p, origin, rot, xr)
+        tp.parent = new
+        new.ports[pname] = tp
+    return new
+
+
+# ---------------------------------------------------------------------------
+# route_quad — 4-sided polygon connecting two ports
+# ---------------------------------------------------------------------------
+
+
+def _port_end_corners(port: Port) -> tuple[Coord, Coord]:
+    """Return the two corner points at the end of `port` (perpendicular to
+    orientation, separated by port.width)."""
+    cx, cy = port.center
+    w = port.width / 2.0
+    o = (port.orientation % 360.0 + 360.0) % 360.0
+    # unit vector perpendicular to port's orientation
+    # port points outward at angle `o`; the port face is perpendicular
+    perp = math.radians(o + 90.0)
+    dx, dy = math.cos(perp), math.sin(perp)
+    return ((cx + dx * w, cy + dy * w), (cx - dx * w, cy - dy * w))
+
+
+def route_quad(
+    port1: Port,
+    port2: Port,
+    layer: Optional[Layer] = None,
+    width1: Optional[float] = None,
+    width2: Optional[float] = None,
+    manhattan_target_step: Optional[float] = None,
+    **_kwargs,
+) -> "Component":
+    """Create a Component holding a 4-vertex polygon that joins `port1`-`port2`.
+
+    Matches the gdsfactory.routing.route_quad signature used in this repo.
+    Each port's end-face becomes one side of the quadrilateral. Widths
+    override the port widths if given.
+    """
+    if layer is None:
+        layer = port1.layer if port1.layer is not None else (0, 0)
+    p1 = port1.copy()
+    p2 = port2.copy()
+    if width1 is not None:
+        p1.width = float(width1)
+    if width2 is not None:
+        p2.width = float(width2)
+    a, b = _port_end_corners(p1)
+    c, d = _port_end_corners(p2)
+    # Order so the quad doesn't self-intersect: a, b, c, d where b→c crosses
+    # from port1 to port2 on one side and d→a on the other.
+    points = [a, b, c, d]
+    # Ensure consistent winding by picking the ordering with the smaller
+    # total perimeter (the non-self-intersecting one).
+    def perim(pts):
+        return sum(math.hypot(pts[(i+1) % 4][0] - pts[i][0],
+                              pts[(i+1) % 4][1] - pts[i][1]) for i in range(4))
+    alt = [a, b, d, c]
+    if perim(alt) < perim(points):
+        points = alt
+    comp = Component(_unique_name("route_quad"))
+    comp.add_polygon(points, layer=tuple(layer))
+    return comp
+
+
+__all__ = [
+    "Component",
+    "ComponentReference",
+    "Port",
+    "Polygon",
+    "Layer",
+    "PathType",
+    "Pdk",
+    "ComponentOrReference",
+    "snap_to_grid",
+    "cell",
+    "clear_cache",
+    "copy",
+    "rectangle",
+    "rectangular_ring",
+    "boolean",
+    "import_gds",
+    "transformed",
+    "route_quad",
+]

--- a/src/glayout/cells/composite/differential_to_single_ended_converter/differential_to_single_ended_converter.py
+++ b/src/glayout/cells/composite/differential_to_single_ended_converter/differential_to_single_ended_converter.py
@@ -1,9 +1,6 @@
-from gdsfactory.cell import cell, clear_cache
+from glayout.backend import Component, ComponentReference, cell, clear_cache, copy, rectangle, route_quad
 from glayout import MappedPDK, sky130,gf180
 from glayout.routing import c_route,L_route,straight_route
-from gdsfactory.component import Component, copy
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.components.rectangle import rectangle
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from glayout.cells.elementary.diff_pair.diff_pair import diff_pair
@@ -11,7 +8,6 @@ from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.primitives.guardring import tapring
 from glayout.primitives.mimcap import mimcap_array, mimcap
 from glayout.primitives.via_gen import via_stack, via_array
-from gdsfactory.routing.route_quad import route_quad
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, movex, movey, to_decimal, to_float, move, align_comp_to_port, get_padding_points_cc
 from glayout.util.port_utils import rename_ports_by_orientation, rename_ports_by_list, add_ports_perimeter, print_ports, set_port_orientation, rename_component_ports
 from glayout.util.snap_to_grid import component_snap_to_grid

--- a/src/glayout/cells/composite/diffpair_cmirror_bias/diff_pair_cmirrorbias.py
+++ b/src/glayout/cells/composite/diffpair_cmirror_bias/diff_pair_cmirrorbias.py
@@ -1,7 +1,4 @@
-from gdsfactory.cell import cell, clear_cache
-from gdsfactory.component import Component, copy
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, ComponentReference, cell, clear_cache, copy, rectangle, route_quad
 from glayout import MappedPDK, sky130,gf180
 from glayout.routing import c_route,L_route,straight_route
 from typing import Optional, Union
@@ -10,7 +7,6 @@ from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.primitives.guardring import tapring
 from glayout.primitives.mimcap import mimcap_array, mimcap
 from glayout.primitives.via_gen import via_stack, via_array
-from gdsfactory.routing.route_quad import route_quad
 from glayout.util.comp_utils import (
     evaluate_bbox,
     prec_ref_center,

--- a/src/glayout/cells/composite/fvf_based_ota/low_voltage_cmirror.py
+++ b/src/glayout/cells/composite/fvf_based_ota/low_voltage_cmirror.py
@@ -1,10 +1,6 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
-from gdsfactory.component import Component
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.cell import cell
-from gdsfactory import Component
-from gdsfactory.components import text_freetype, rectangle
+from glayout.backend import Component, ComponentReference, cell, rectangle
 from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.util.comp_utils import evaluate_bbox, prec_center, align_comp_to_port, prec_ref_center
 from glayout.util.snap_to_grid import component_snap_to_grid

--- a/src/glayout/cells/composite/fvf_based_ota/n_block.py
+++ b/src/glayout/cells/composite/fvf_based_ota/n_block.py
@@ -1,13 +1,10 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
-from gdsfactory import Component
-from gdsfactory.cell import cell
-from gdsfactory.component_reference import ComponentReference
+from glayout.backend import Component, ComponentReference, cell, rectangle
 
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, prec_center, align_comp_to_port
 from glayout.util.port_utils import rename_ports_by_orientation
 from glayout.util.snap_to_grid import component_snap_to_grid
-from gdsfactory.components import text_freetype, rectangle
 
 from glayout.spice.netlist import Netlist
 from glayout.routing.straight_route import straight_route

--- a/src/glayout/cells/composite/fvf_based_ota/ota.py
+++ b/src/glayout/cells/composite/fvf_based_ota/ota.py
@@ -1,13 +1,10 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
-from gdsfactory import Component
-from gdsfactory.cell import cell
-from gdsfactory.component_reference import ComponentReference
+from glayout.backend import Component, ComponentReference, cell, rectangle
 
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, prec_center, align_comp_to_port
 from glayout.util.port_utils import rename_ports_by_orientation
 from glayout.util.snap_to_grid import component_snap_to_grid
-from gdsfactory.components import text_freetype, rectangle
 from glayout.spice.netlist import Netlist
 
 

--- a/src/glayout/cells/composite/fvf_based_ota/p_block.py
+++ b/src/glayout/cells/composite/fvf_based_ota/p_block.py
@@ -1,9 +1,6 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory import Component
+from glayout.backend import Component, ComponentReference, cell, rectangle
 from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.util.comp_utils import evaluate_bbox, prec_center, prec_ref_center
 from glayout.util.snap_to_grid import component_snap_to_grid
@@ -15,7 +12,6 @@ from glayout.primitives.guardring import tapring
 from glayout.util.port_utils import add_ports_perimeter, rename_ports_by_list
 from glayout.spice.netlist import Netlist
 from glayout.primitives.via_gen import via_stack
-from gdsfactory.components import text_freetype, rectangle
 from glayout.placement.four_transistor_interdigitized import generic_4T_interdigitzed
 
 def p_block_netlist(pdk: MappedPDK, pblock: tuple[float, float, int]) -> Netlist:

--- a/src/glayout/cells/composite/fvf_based_ota/sky130_ota_tapeout.py
+++ b/src/glayout/cells/composite/fvf_based_ota/sky130_ota_tapeout.py
@@ -4,11 +4,9 @@ environ['OPENBLAS_NUM_THREADS'] = '1'
 # path to glayout
 sys.path.append(path.join(path.dirname(__file__), '../../'))
 
-from gdsfactory.read.import_gds import import_gds
-from gdsfactory.components import text_freetype, rectangle
+from glayout.backend import Component, cell, clear_cache, import_gds, rectangle
 from glayout.util.comp_utils import prec_array, movey, align_comp_to_port, prec_ref_center
 from glayout.util.port_utils import add_ports_perimeter, print_ports
-from gdsfactory.component import Component
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.cells.composite.fvf_based_ota.ota import super_class_AB_OTA
 from glayout.routing.L_route import L_route
@@ -17,10 +15,8 @@ from glayout.routing.straight_route import straight_route
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, prec_center, align_comp_to_port
 from glayout.util.port_utils import rename_ports_by_orientation
 from glayout.util.snap_to_grid import component_snap_to_grid
-from gdsfactory.components import text_freetype, rectangle
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.primitives.via_gen import via_array, via_stack
-from gdsfactory.cell import cell, clear_cache
 import numpy as np
 from subprocess import Popen
 from pathlib import Path

--- a/src/glayout/cells/composite/low_voltage_cmirror/low_voltage_cmirror.py
+++ b/src/glayout/cells/composite/low_voltage_cmirror/low_voltage_cmirror.py
@@ -1,10 +1,6 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
-from gdsfactory.component import Component
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.cell import cell
-from gdsfactory import Component
-from gdsfactory.components import text_freetype, rectangle
+from glayout.backend import Component, ComponentReference, cell, rectangle
 from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.util.comp_utils import evaluate_bbox, prec_center, align_comp_to_port, prec_ref_center
 from glayout.util.snap_to_grid import component_snap_to_grid

--- a/src/glayout/cells/composite/opamp/diff_pair_stackedcmirror.py
+++ b/src/glayout/cells/composite/opamp/diff_pair_stackedcmirror.py
@@ -1,7 +1,4 @@
-from gdsfactory.cell import cell, clear_cache
-from gdsfactory.component import Component, copy
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, ComponentReference, cell, clear_cache, copy, rectangle, route_quad
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from glayout.cells.elementary.diff_pair import diff_pair
@@ -11,7 +8,6 @@ from glayout.primitives.mimcap import mimcap_array, mimcap
 from glayout.primitives.via_gen import via_stack, via_array
 from glayout.routing.L_route import L_route
 from glayout.routing.c_route import c_route
-from gdsfactory.routing.route_quad import route_quad
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, movex, movey, to_decimal, to_float, move, align_comp_to_port, get_padding_points_cc
 from glayout.util.port_utils import rename_ports_by_orientation, rename_ports_by_list, add_ports_perimeter, print_ports, set_port_orientation, rename_component_ports
 from glayout.routing.straight_route import straight_route

--- a/src/glayout/cells/composite/opamp/opamp.py
+++ b/src/glayout/cells/composite/opamp/opamp.py
@@ -1,7 +1,4 @@
-from gdsfactory.cell import cell, clear_cache
-from gdsfactory.component import Component, copy
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, ComponentReference, cell, clear_cache, copy, rectangle, route_quad
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from glayout.primitives.fet import nmos, pmos, multiplier
@@ -11,7 +8,6 @@ from glayout.primitives.mimcap import mimcap_array, mimcap
 from glayout.routing.L_route import L_route
 from glayout.routing.c_route import c_route
 from glayout.primitives.via_gen import via_stack, via_array
-from gdsfactory.routing.route_quad import route_quad
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, movex, movey, to_decimal, to_float, move, align_comp_to_port, get_padding_points_cc
 from glayout.util.port_utils import rename_ports_by_orientation, rename_ports_by_list, add_ports_perimeter, print_ports, set_port_orientation, rename_component_ports
 from glayout.routing.straight_route import straight_route

--- a/src/glayout/cells/composite/opamp/opamp_twostage.py
+++ b/src/glayout/cells/composite/opamp/opamp_twostage.py
@@ -1,7 +1,4 @@
-from gdsfactory.cell import cell, clear_cache
-from gdsfactory.component import Component, copy
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, ComponentReference, cell, clear_cache, copy, rectangle, route_quad
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from glayout.primitives.fet import nmos, pmos, multiplier
@@ -11,7 +8,6 @@ from glayout.primitives.mimcap import mimcap_array, mimcap
 from glayout.routing.L_route import L_route
 from glayout.routing.c_route import c_route
 from glayout.primitives.via_gen import via_stack, via_array
-from gdsfactory.routing.route_quad import route_quad
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, movex, movey, to_decimal, to_float, move, align_comp_to_port, get_padding_points_cc
 from glayout.util.port_utils import rename_ports_by_orientation, rename_ports_by_list, add_ports_perimeter, print_ports, set_port_orientation, rename_component_ports
 from glayout.routing.straight_route import straight_route

--- a/src/glayout/cells/composite/opamp/row_csamplifier_diff_to_single_ended_converter.py
+++ b/src/glayout/cells/composite/opamp/row_csamplifier_diff_to_single_ended_converter.py
@@ -1,7 +1,4 @@
-from gdsfactory.cell import cell, clear_cache
-from gdsfactory.component import Component, copy
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, ComponentReference, cell, clear_cache, copy, rectangle, route_quad
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from glayout.primitives.fet import nmos, pmos, multiplier
@@ -11,7 +8,6 @@ from glayout.primitives.mimcap import mimcap_array, mimcap
 from glayout.routing.L_route import L_route
 from glayout.routing.c_route import c_route
 from glayout.primitives.via_gen import via_stack, via_array
-from gdsfactory.routing.route_quad import route_quad
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, movex, movey, to_decimal, to_float, move, align_comp_to_port, get_padding_points_cc
 from glayout.util.port_utils import rename_ports_by_orientation, rename_ports_by_list, add_ports_perimeter, print_ports, set_port_orientation, rename_component_ports
 from glayout.routing.straight_route import straight_route

--- a/src/glayout/cells/composite/stacked_current_mirror/stacked_current_mirror.py
+++ b/src/glayout/cells/composite/stacked_current_mirror/stacked_current_mirror.py
@@ -1,8 +1,5 @@
 from glayout import MappedPDK, sky130,gf180
-from gdsfactory.cell import cell, clear_cache
-from gdsfactory.component import Component, copy
-from gdsfactory.component_reference import ComponentReference
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, ComponentReference, cell, clear_cache, copy, rectangle, route_quad
 from typing import Optional, Union
 from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.cells.elementary.diff_pair import diff_pair
@@ -10,7 +7,6 @@ from glayout.primitives.guardring import tapring
 from glayout.primitives.mimcap import mimcap_array, mimcap
 from glayout.routing import c_route,L_route,straight_route
 from glayout.primitives.via_gen import via_stack, via_array
-from gdsfactory.routing.route_quad import route_quad
 from glayout.util.comp_utils import evaluate_bbox, prec_ref_center, movex, movey, to_decimal, to_float, move, align_comp_to_port, get_padding_points_cc
 from glayout.util.port_utils import rename_ports_by_orientation, rename_ports_by_list, add_ports_perimeter, print_ports, set_port_orientation, rename_component_ports
 from glayout.util.snap_to_grid import component_snap_to_grid

--- a/src/glayout/cells/elementary/FVF/fvf.py
+++ b/src/glayout/cells/elementary/FVF/fvf.py
@@ -1,8 +1,6 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory import Component
+from glayout.backend import Component, cell, rectangle
 from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.util.comp_utils import evaluate_bbox, prec_center, prec_ref_center, align_comp_to_port
 from glayout.util.snap_to_grid import component_snap_to_grid
@@ -14,7 +12,6 @@ from glayout.primitives.guardring import tapring
 from glayout.util.port_utils import add_ports_perimeter
 from glayout.spice.netlist import Netlist
 from glayout.primitives.via_gen import via_stack
-from gdsfactory.components import text_freetype, rectangle
 try:
     from glayout.verification.evaluator_wrapper import run_evaluation
 except ImportError:

--- a/src/glayout/cells/elementary/current_mirror/current_mirror.py
+++ b/src/glayout/cells/elementary/current_mirror/current_mirror.py
@@ -7,12 +7,10 @@ from glayout.spice.netlist import Netlist
 from glayout.primitives.fet import nmos, pmos
 from glayout.primitives.guardring import tapring
 from glayout.util.port_utils import add_ports_perimeter,rename_ports_by_orientation
-from gdsfactory.component import Component
-from gdsfactory.cell import cell
+from glayout.backend import Component, cell, rectangle
 from glayout.util.comp_utils import evaluate_bbox, prec_center, prec_ref_center, align_comp_to_port
 from typing import Optional, Union 
 from glayout.primitives.via_gen import via_stack
-from gdsfactory.components import text_freetype, rectangle
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
 try:
     from glayout.verification.evaluator_wrapper import run_evaluation

--- a/src/glayout/cells/elementary/diff_pair/diff_pair.py
+++ b/src/glayout/cells/elementary/diff_pair/diff_pair.py
@@ -1,10 +1,6 @@
 from typing import Optional, Union
 
-from gdsfactory.cell import cell
-from gdsfactory.component import Component, copy
-from gdsfactory.components.rectangle import rectangle
-from gdsfactory.routing.route_quad import route_quad
-from gdsfactory.routing.route_sharp import route_sharp
+from glayout.backend import Component, cell, copy, rectangle, route_quad
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.util.comp_utils import align_comp_to_port, evaluate_bbox, movex, movey
 from glayout.util.port_utils import (
@@ -25,7 +21,6 @@ from glayout.routing.smart_route import smart_route
 from glayout.routing.straight_route import straight_route
 from glayout.spice import Netlist
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
-from gdsfactory.components import text_freetype
 try:
     from glayout.verification.evaluator_wrapper import run_evaluation
 except ImportError:

--- a/src/glayout/cells/elementary/transmission_gate/transmission_gate.py
+++ b/src/glayout/cells/elementary/transmission_gate/transmission_gate.py
@@ -1,7 +1,5 @@
 from glayout import MappedPDK, sky130,gf180
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory import Component
+from glayout.backend import Component, cell, rectangle
 from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.util.comp_utils import evaluate_bbox, prec_center, align_comp_to_port, movex, movey
 from glayout.util.snap_to_grid import component_snap_to_grid
@@ -13,7 +11,6 @@ from glayout.primitives.guardring import tapring
 from glayout.util.port_utils import add_ports_perimeter
 from glayout.spice.netlist import Netlist
 from glayout.primitives.via_gen import via_stack
-from gdsfactory.components import text_freetype, rectangle
 try:
     from glayout.verification.evaluator_wrapper import run_evaluation
 except ImportError:

--- a/src/glayout/pdk/mappedpdk.py
+++ b/src/glayout/pdk/mappedpdk.py
@@ -2,8 +2,7 @@
 usage: from mappedpdk import MappedPDK
 """
 import re
-from gdsfactory.pdk import Pdk
-from gdsfactory.typings import Component, PathType, Layer
+from glayout.backend import Component, Layer, PathType, Pdk
 from pydantic import validator, StrictStr, ValidationError
 from typing import ClassVar, Optional, Any, Union, Literal, Iterable, TypedDict
 from pathlib import Path

--- a/src/glayout/pdk/sky130_mapped/sky130_add_npc.py
+++ b/src/glayout/pdk/sky130_mapped/sky130_add_npc.py
@@ -1,6 +1,4 @@
-from gdsfactory.component import Component
-from gdsfactory.polygon import Polygon
-from gdsfactory.geometry.boolean import boolean
+from glayout.backend import Component, Polygon, boolean
 
 
 def sky130_add_npc(comp: Component) -> Component:

--- a/src/glayout/placement/common_centroid_ab_ba.py
+++ b/src/glayout/placement/common_centroid_ab_ba.py
@@ -7,11 +7,10 @@ from glayout.util.comp_utils import evaluate_bbox, movex, move, movey, align_com
 from glayout.util.port_utils import set_port_orientation, rename_ports_by_orientation, create_private_ports
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.primitives.guardring import tapring
-from gdsfactory.components import rectangle
+from glayout.backend import Component, rectangle
 from typing import Union, Optional
 from itertools import product
 
-from gdsfactory import Component
 
 
 def common_centroid_ab_ba(

--- a/src/glayout/placement/four_transistor_interdigitized.py
+++ b/src/glayout/placement/four_transistor_interdigitized.py
@@ -5,12 +5,10 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.placement.two_transistor_interdigitized import two_nfet_interdigitized, two_pfet_interdigitized
 from typing import Literal, Optional
-from gdsfactory import Component
-from gdsfactory.component_reference import ComponentReference
+from glayout.backend import Component, ComponentReference, rectangle
 from glayout.util.comp_utils import evaluate_bbox, movey, align_comp_to_port
 from glayout.primitives.guardring import tapring
 from glayout.spice.netlist import Netlist
-from gdsfactory.components import text_freetype, rectangle
 from glayout.primitives.via_gen import via_stack
 
 #two seperate bulk nodes

--- a/src/glayout/placement/two_transistor_interdigitized.py
+++ b/src/glayout/placement/two_transistor_interdigitized.py
@@ -1,21 +1,18 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from pydantic import validate_arguments
-from gdsfactory.component import Component
+from glayout.backend import Component, clear_cache, rectangle, transformed
 from glayout.primitives.fet import nmos, pmos, multiplier
 from glayout.util.comp_utils import evaluate_bbox
 from typing import Literal, Union
 from glayout.util.port_utils import rename_ports_by_orientation, rename_ports_by_list, create_private_ports
 from glayout.util.comp_utils import prec_ref_center,evaluate_bbox, prec_center, align_comp_to_port
 from glayout.routing.straight_route import straight_route
-from gdsfactory.functions import transformed
 from glayout.primitives.guardring import tapring
 from glayout.util.port_utils import add_ports_perimeter
-from gdsfactory.cell import clear_cache
 from typing import Literal, Optional, Union
 from glayout.pdk.sky130_mapped import sky130_mapped_pdk
 from glayout.pdk.gf180_mapped import gf180_mapped_pdk
 from glayout.spice.netlist import Netlist
-from gdsfactory.components import text_freetype, rectangle
 from glayout.primitives.via_gen import via_stack
 #from glayout.placement.two_transistor_interdigitized import two_nfet_interdigitized; from glayout.pdk.sky130_mapped import sky130_mapped_pdk as pdk; biasParams=[6,2,4]; rmult=2
 def add_two_int_labels(two_int_in: Component,

--- a/src/glayout/placement/two_transistor_place.py
+++ b/src/glayout/placement/two_transistor_place.py
@@ -1,6 +1,6 @@
 from glayout.pdk.mappedpdk import MappedPDK
 from pydantic import validate_arguments
-from gdsfactory.component import Component
+from glayout.backend import Component
 from typing import Callable
 from glayout.primitives.fet import nmos, pmos
 from glayout.util.comp_utils import evaluate_bbox

--- a/src/glayout/primitives/bjt.py
+++ b/src/glayout/primitives/bjt.py
@@ -11,9 +11,7 @@ from glayout.util.port_utils import add_ports_perimeter, rename_ports_by_list, r
 from glayout.util.comp_utils import prec_center, prec_array, prec_ref_center, to_float, move, align_comp_to_port, evaluate_bbox, to_decimal
 from glayout.primitives.via_gen import via_array, via_stack
 from glayout.routing.straight_route import straight_route
-from gdsfactory.cell import cell
-from gdsfactory import Component
-from gdsfactory.components import text_freetype, rectangle, rectangular_ring
+from glayout.backend import Component, cell, rectangle, rectangular_ring
 
 
 def get_number_contacts(dims, contact_dims, padding, spacing ):

--- a/src/glayout/primitives/fet.py
+++ b/src/glayout/primitives/fet.py
@@ -1,7 +1,4 @@
-from gdsfactory.grid import grid
-from gdsfactory.cell import cell
-from gdsfactory.component import Component, copy
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, cell, copy, rectangle
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from glayout.primitives.via_gen import via_array, via_stack

--- a/src/glayout/primitives/guardring.py
+++ b/src/glayout/primitives/guardring.py
@@ -1,8 +1,5 @@
 from glayout.pdk.mappedpdk import MappedPDK
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory.components.rectangle import rectangle
-from gdsfactory.components.rectangular_ring import rectangular_ring
+from glayout.backend import Component, cell, rectangle, rectangular_ring
 from glayout.primitives.via_gen import via_array, via_stack
 from typing import Optional
 from glayout.util.comp_utils import to_decimal, to_float, evaluate_bbox

--- a/src/glayout/primitives/mimcap.py
+++ b/src/glayout/primitives/mimcap.py
@@ -1,6 +1,4 @@
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, cell, rectangle
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional
 from glayout.primitives.via_gen import via_array

--- a/src/glayout/primitives/resistor.py
+++ b/src/glayout/primitives/resistor.py
@@ -6,8 +6,7 @@ from glayout.routing.smart_route import smart_route
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.primitives.guardring import tapring
 from glayout.util.comp_utils import evaluate_bbox, add_ports_perimeter
-from gdsfactory.component import Component
-from gdsfactory.cell import cell 
+from glayout.backend import Component, cell
 from typing import Optional
 from glayout import sky130
 from glayout.spice import Netlist

--- a/src/glayout/primitives/via_gen.py
+++ b/src/glayout/primitives/via_gen.py
@@ -1,13 +1,4 @@
-try:
-    from gdsfactory.cell import cell
-except ModuleNotFoundError:
-    def cell(func=None, **kwargs):
-        if func:
-            return func
-        return lambda f: f
-
-from gdsfactory.component import Component
-from gdsfactory.components.rectangle import rectangle
+from glayout.backend import Component, cell, rectangle
 from pydantic import validate_arguments
 from glayout.pdk.mappedpdk import MappedPDK
 from math import floor

--- a/src/glayout/routing/L_route.py
+++ b/src/glayout/routing/L_route.py
@@ -1,6 +1,4 @@
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory.port import Port
+from glayout.backend import Component, Port, cell
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from glayout.primitives.via_gen import via_stack, via_array

--- a/src/glayout/routing/c_route.py
+++ b/src/glayout/routing/c_route.py
@@ -1,16 +1,12 @@
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory.port import Port
+from glayout.backend import Component, Port, cell, rectangle, snap_to_grid
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional, Union
 from math import isclose
 from glayout.primitives.via_gen import via_stack, via_array
 from glayout.routing.straight_route import straight_route
-from gdsfactory.components.rectangle import rectangle
 from glayout.util.comp_utils import evaluate_bbox, get_primitive_rectangle, to_float, prec_ref_center
 from glayout.util.port_utils import add_ports_perimeter, rename_ports_by_orientation, rename_ports_by_list, print_ports, set_port_width, set_port_orientation, get_orientation
 from pydantic import validate_arguments
-from gdsfactory.snap import snap_to_grid
 
 
 @validate_arguments

--- a/src/glayout/routing/smart_route.py
+++ b/src/glayout/routing/smart_route.py
@@ -1,8 +1,7 @@
 import warnings
 from typing import Optional, Union
 
-from gdsfactory import Component, ComponentReference
-from gdsfactory.port import Port
+from glayout.backend import Component, ComponentReference, Port
 from glayout.pdk.mappedpdk import MappedPDK
 from glayout.util.comp_utils import align_comp_to_port, movex
 from glayout.util.port_utils import (

--- a/src/glayout/routing/straight_route.py
+++ b/src/glayout/routing/straight_route.py
@@ -1,10 +1,7 @@
-from gdsfactory.cell import cell
-from gdsfactory.component import Component
-from gdsfactory.port import Port
+from glayout.backend import Component, Port, cell, rectangle
 from glayout.pdk.mappedpdk import MappedPDK
 from typing import Optional
 from glayout.primitives.via_gen import via_stack, via_array
-from gdsfactory.components.rectangle import rectangle
 from glayout.util.comp_utils import evaluate_bbox, align_comp_to_port
 from glayout.util.port_utils import assert_port_manhattan, set_port_orientation, add_ports_perimeter
 from gdstk import rectangle as primitive_rectangle

--- a/src/glayout/util/comp_utils.py
+++ b/src/glayout/util/comp_utils.py
@@ -1,12 +1,7 @@
 from pydantic import validate_arguments
-from gdsfactory.snap import snap_to_grid
-from gdsfactory.typings import Component, ComponentReference
-from gdsfactory.components.rectangle import rectangle
-from gdsfactory.port import Port
+from glayout.backend import Component, ComponentReference, Port, rectangle, snap_to_grid, transformed
 from typing import Callable, Union, Optional, Iterable
 from decimal import Decimal
-from gdsfactory.functions import transformed
-from gdsfactory.functions import move as __gf_move
 from glayout.pdk.mappedpdk import MappedPDK
 from gdstk import rectangle as primitive_rectangle
 from .port_utils import add_ports_perimeter, rename_ports_by_list, parse_direction

--- a/src/glayout/util/component_array_create.py
+++ b/src/glayout/util/component_array_create.py
@@ -1,9 +1,7 @@
-from gdsfactory.read.import_gds import import_gds
-from gdsfactory.component import Component
+from glayout.backend import Component, Pdk, import_gds
 from pathlib import Path
 import os
 import math
-from gdsfactory.pdk import Pdk
 from pathlib import Path
 from typing import Union, Optional
 from pydantic import validate_arguments

--- a/src/glayout/util/geometry.py
+++ b/src/glayout/util/geometry.py
@@ -5,10 +5,7 @@ Geometry utility functions for Glayout.
 from typing import Optional, Union, Tuple, List
 from pathlib import Path
 
-from gdsfactory import cell
-from gdsfactory.component import Component
-from gdsfactory import ComponentReference as Reference
-from gdsfactory.typings import Layer, ComponentOrReference
+from glayout.backend import Component, ComponentOrReference, ComponentReference as Reference, Layer, cell
 from pydantic import validate_arguments
 
 from ..pdk.mappedpdk import MappedPDK

--- a/src/glayout/util/port_utils.py
+++ b/src/glayout/util/port_utils.py
@@ -1,7 +1,5 @@
 from pydantic import validate_arguments
-from gdsfactory.typings import Component, ComponentReference
-from gdsfactory.components.rectangle import rectangle
-from gdsfactory.port import Port
+from glayout.backend import Component, ComponentReference, Port, rectangle
 from typing import Callable, Union, Optional
 from decimal import Decimal
 from pathlib import Path
@@ -503,7 +501,6 @@ def print_port_tree_all_cells() -> list:
 	from glayout.flow.routing.c_route import c_route
 	from glayout.flow.routing.L_route import L_route
 	from glayout.flow.pdk.sky130_mapped import sky130_mapped_pdk as pdk
-	from gdsfactory.port import Port
 	print("saving via_stack, via_array, opamp, mimcap, mimcap_array, tapring, multiplier, nmos, pmos, diff_pair, straight_route, c_route, L_route Ports to txt files")
 	celllist = list()
 	celllist.append(["via_stack",via_stack(pdk, "active_diff","met5")])

--- a/src/glayout/util/routing.py
+++ b/src/glayout/util/routing.py
@@ -3,8 +3,7 @@ Routing utility functions for Glayout.
 """
 
 from typing import Optional, Tuple
-from gdsfactory.component import Component
-from gdsfactory.typings import Port
+from glayout.backend import Component, Port
 from ..pdk.mappedpdk import MappedPDK
 from .geometry import rectangle
 

--- a/src/glayout/util/snap_to_grid.py
+++ b/src/glayout/util/snap_to_grid.py
@@ -1,4 +1,4 @@
-from gdsfactory.typings import Component
+from glayout.backend import Component
 from pydantic import validate_arguments
 
 

--- a/src/glayout/verification/evaluator_wrapper.py
+++ b/src/glayout/verification/evaluator_wrapper.py
@@ -6,7 +6,7 @@ import logging
 import shutil
 from datetime import datetime
 from pathlib import Path
-from gdsfactory.typings import Component
+from glayout.backend import Component
 
 # Make run_pex.sh executable if it exists
 _evaluator_box_dir = Path(__file__).parent

--- a/src/glayout/verification/physical_features.py
+++ b/src/glayout/verification/physical_features.py
@@ -4,8 +4,7 @@ import re
 import subprocess
 import shutil
 from pathlib import Path
-from gdsfactory.typings import Component
-from gdsfactory.geometry.boolean import boolean
+from glayout.backend import Component, boolean
 
 # Get the path to run_pex.sh in the evaluator_box directory
 _EVALUATOR_BOX_DIR = Path(__file__).parent

--- a/src/glayout/verification/verification.py
+++ b/src/glayout/verification/verification.py
@@ -7,7 +7,7 @@ import tempfile
 import sys
 from pathlib import Path
 from glayout import MappedPDK, sky130,gf180
-from gdsfactory.typings import Component
+from glayout.backend import Component
 
 def parse_drc_report(report_content: str) -> dict:
     """

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,17 +1,48 @@
-## Regression Tests
+## Tests
 
-This folder contains repository-level regression checks for structural changes
-such as import-path migrations.
+This folder has two categories of tests:
 
-Run the default suite from the repository root:
+1. **Structural / regression** — import-path canonicalization and repo layout
+   (`test_import_paths.py`, `test_repo_layout.py`). These run fast and are
+   gated by `tests/run_regression.sh`.
+
+2. **Layout-generation** — exercise the actual layout engine:
+   - `test_gdstk_backend.py` — sanity checks for the gdstk-backed
+     `Component` / `ComponentReference` / `Port`.
+   - `test_cells_layout.py` — builds every cell in `src/glayout/cells/`,
+     verifies the bounding box is non-empty, writes a GDS, and round-trips
+     it through `gdstk.read_gds`. Known-broken cells are marked `xfail` with
+     the failing error summary; heavyweight cells are marked `slow`.
+
+### Running
+
+From the repo root:
 
 ```bash
-tests/run_regression.sh
+# fast tests only
+PYTHONPATH=src pytest tests/
+
+# include slow/heavyweight cells (adds several minutes)
+PYTHONPATH=src pytest tests/ --runslow
+
+# run a single parametrized case
+PYTHONPATH=src pytest tests/test_cells_layout.py -k diff_pair
 ```
 
-The current suite focuses on:
+### Backend selection
 
-- canonical imports under `glayout.cells`
-- compatibility imports under `glayout.blocks`
-- canonical imports under `glayout.verification`
-- repository layout checks for the `legacy/atlas` move
+Layout tests default to the gdstk backend (`GLAYOUT_BACKEND=gdstk`), set in
+`conftest.py`. Override by exporting a different value before pytest runs if
+you want to cross-check against gdsfactory:
+
+```bash
+GLAYOUT_BACKEND=gdsfactory PYTHONPATH=src pytest tests/
+```
+
+### Expanding the cell matrix
+
+`test_cells_layout.py` is driven by a single `CASES` list of `CellCase`
+entries. Add a new cell by appending a row with its module path, function
+name, and a lambda that returns the kwargs dict (so the pdk fixture can be
+injected lazily). Mark `xfail=` with the short reason when a cell is known
+broken, and `slow=True` for cells that take minutes to build.

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,10 +9,14 @@ This folder has two categories of tests:
 2. **Layout-generation** — exercise the actual layout engine:
    - `test_gdstk_backend.py` — sanity checks for the gdstk-backed
      `Component` / `ComponentReference` / `Port`.
-   - `test_cells_layout.py` — builds every cell in `src/glayout/cells/`,
-     verifies the bounding box is non-empty, writes a GDS, and round-trips
-     it through `gdstk.read_gds`. Known-broken cells are marked `xfail` with
-     the failing error summary; heavyweight cells are marked `slow`.
+   - `test_cells_layout.py` — builds every cell in `src/glayout/cells/`
+     under **both** the `gdstk` and `gdsfactory` backends, verifies each
+     build's bounding box is non-empty and writes a GDS, and records the
+     wall-clock time. The terminal summary prints a per-cell timing table
+     with the gdsfactory-vs-gdstk speedup. Known-broken cells are marked
+     `xfail`; heavyweight cells are marked `slow`.
+   - `_cell_worker.py` — subprocess entry point. Each (cell, backend) pair
+     runs in its own interpreter so the backend binding is isolated.
 
 ### Running
 
@@ -31,13 +35,34 @@ PYTHONPATH=src pytest tests/test_cells_layout.py -k diff_pair
 
 ### Backend selection
 
-Layout tests default to the gdstk backend (`GLAYOUT_BACKEND=gdstk`), set in
-`conftest.py`. Override by exporting a different value before pytest runs if
-you want to cross-check against gdsfactory:
+`test_cells_layout.py` **always runs both backends** — each cell is
+parametrized as `[<cell>-gdstk, <cell>-gdsfactory]` and dispatched to a
+subprocess with `GLAYOUT_BACKEND` set accordingly, so there's no state
+leakage between backends. If a backend isn't installed the corresponding
+cases skip cleanly.
 
-```bash
-GLAYOUT_BACKEND=gdsfactory PYTHONPATH=src pytest tests/
+The other tests (`test_gdstk_backend.py`, structural tests) default to the
+gdstk backend (set in `conftest.py`). Override by exporting
+`GLAYOUT_BACKEND=gdsfactory` before running pytest.
+
+### Reading the timing table
+
 ```
+cell                         gdstk (s)  gdsfactory (s)   speedup   status
+--------------------------------------------------------------------------
+current_mirror                   0.247           6.412    25.93x   ok/ok
+diff_pair                        0.376           6.210    16.51x   ok/ok
+...
+TOTAL (paired ok)                6.253          62.929    10.06x   6 cells
+```
+
+Columns:
+- `gdstk (s)` / `gdsfactory (s)` — wall-clock build time inside the worker.
+- `speedup` — `gdsfactory / gdstk`; blank when either side didn't succeed.
+- `status` — `ok` / `error` / `timeout` for each backend.
+
+The `TOTAL (paired ok)` row sums only the cells that succeeded on both
+backends, so the aggregate speedup isn't skewed by partial results.
 
 ### Expanding the cell matrix
 

--- a/tests/_cell_worker.py
+++ b/tests/_cell_worker.py
@@ -1,0 +1,141 @@
+"""Subprocess worker that builds a single cell and reports the result as JSON.
+
+Run directly:
+    python -m tests._cell_worker <module> <func> <kwargs_json>
+
+Prints one line of JSON on stdout with the measured elapsed time and either
+the success fields or the error message.
+
+The worker isolates per-(cell, backend) state. `GLAYOUT_BACKEND` must already
+be set in the environment when the worker starts — once glayout is imported,
+the backend binding is frozen for the process.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+import time
+import traceback
+
+
+def _listify_to_tuple(obj):
+    """JSON has no tuple type; recursively promote lists back to tuples so
+    pydantic-validated signatures (which expect `tuple[...]`) accept them."""
+    if isinstance(obj, list):
+        return tuple(_listify_to_tuple(x) for x in obj)
+    if isinstance(obj, dict):
+        return {k: _listify_to_tuple(v) for k, v in obj.items()}
+    return obj
+
+
+def _materialize(result):
+    """Wrap a reference / tuple / Component return into a Component."""
+    from glayout.backend import Component, ComponentReference
+    if isinstance(result, Component):
+        return result
+    wrapper = Component("test_wrapper")
+    if isinstance(result, ComponentReference):
+        wrapper.add(result)
+        return wrapper
+    if isinstance(result, (tuple, list)):
+        added = False
+        for item in result:
+            if isinstance(item, ComponentReference):
+                wrapper.add(item)
+                added = True
+            elif isinstance(item, Component):
+                wrapper.add(wrapper << item)
+                added = True
+        if not added:
+            raise AssertionError(
+                f"cell returned a container with no Component/Reference: {result!r}"
+            )
+        return wrapper
+    raise AssertionError(f"unexpected return type {type(result).__name__}")
+
+
+def _bbox_tuple(component) -> list:
+    """Normalize bbox to a JSON-serializable nested list. The gdsfactory
+    backend returns a numpy array; the gdstk backend returns a tuple."""
+    bb = component.bbox
+    # numpy array or list-of-lists
+    try:
+        (x0, y0), (x1, y1) = bb
+    except Exception:
+        # numpy 2D array
+        import numpy as np
+        arr = np.asarray(bb)
+        x0, y0 = float(arr[0, 0]), float(arr[0, 1])
+        x1, y1 = float(arr[1, 0]), float(arr[1, 1])
+    return [[float(x0), float(y0)], [float(x1), float(y1)]]
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(json.dumps({
+            "status": "error",
+            "error": "usage: _cell_worker.py <module> <func> <kwargs_json>",
+        }))
+        return 2
+
+    module_path, func_name, kwargs_json = sys.argv[1], sys.argv[2], sys.argv[3]
+    kwargs = _listify_to_tuple(json.loads(kwargs_json))
+
+    # Build a short env summary for post-hoc debugging.
+    backend = os.environ.get("GLAYOUT_BACKEND", "<unset>")
+
+    # Import / construct pdk OUTSIDE the measured window — we want to time
+    # cell construction, not module import. (Each subprocess is fresh
+    # anyway; we just want apples-to-apples between backends.)
+    try:
+        from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk as pdk
+    except Exception as e:
+        print(json.dumps({
+            "status": "error",
+            "error": f"pdk import failed: {type(e).__name__}: {e}",
+            "backend": backend,
+        }))
+        return 1
+
+    kwargs["pdk"] = pdk
+
+    t0 = time.perf_counter()
+    try:
+        mod = importlib.import_module(module_path)
+        func = getattr(mod, func_name)
+        result = func(**kwargs)
+        component = _materialize(result)
+        bbox = _bbox_tuple(component)
+
+        with tempfile.TemporaryDirectory() as td:
+            gds_path = os.path.join(td, "out.gds")
+            component.write_gds(gds_path)
+            gds_size = os.path.getsize(gds_path)
+
+        elapsed = time.perf_counter() - t0
+        print(json.dumps({
+            "status": "ok",
+            "backend": backend,
+            "elapsed_s": elapsed,
+            "bbox": bbox,
+            "gds_bytes": gds_size,
+        }))
+        return 0
+    except Exception as e:
+        elapsed = time.perf_counter() - t0
+        summary = traceback.format_exception_only(type(e), e)[-1].strip()
+        print(json.dumps({
+            "status": "error",
+            "backend": backend,
+            "elapsed_s": elapsed,
+            "error": summary,
+            "traceback": traceback.format_exc(),
+        }))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared pytest configuration and fixtures.
+
+Sets the gdstk backend by default since it doesn't require gdsfactory to be
+installed. Callers can override with `GLAYOUT_BACKEND=gdsfactory` if gdsfactory
+is available in the environment.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("GLAYOUT_BACKEND", "gdstk")
+# MappedPDK requires PDK_ROOT to be set (used to locate DRC/LVS files). The
+# tests here only build layouts, so any existing path is fine.
+os.environ.setdefault("PDK_ROOT", "/tmp")
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        default=False,
+        help="Also run tests marked @pytest.mark.slow (heavyweight cells that "
+             "take minutes to build).",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="--runslow not set")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+@pytest.fixture(scope="session")
+def sky130_pdk():
+    """The sky130 MappedPDK instance used for layout tests."""
+    from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk
+    return sky130_mapped_pdk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,22 @@
-"""Shared pytest configuration and fixtures.
+"""Shared pytest configuration.
 
-Sets the gdstk backend by default since it doesn't require gdsfactory to be
-installed. Callers can override with `GLAYOUT_BACKEND=gdsfactory` if gdsfactory
-is available in the environment.
+Layout tests run each (cell, backend) combination in an isolated subprocess,
+so the parent process's backend never matters. We still default
+`GLAYOUT_BACKEND=gdstk` so structural/regression tests that import glayout
+directly don't require gdsfactory to be installed.
 """
 import os
 
 import pytest
 
 os.environ.setdefault("GLAYOUT_BACKEND", "gdstk")
-# MappedPDK requires PDK_ROOT to be set (used to locate DRC/LVS files). The
-# tests here only build layouts, so any existing path is fine.
 os.environ.setdefault("PDK_ROOT", "/tmp")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "slow: marks tests that can take several minutes (--runslow to run)"
+    )
 
 
 def pytest_addoption(parser):
@@ -20,7 +25,7 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Also run tests marked @pytest.mark.slow (heavyweight cells that "
-             "take minutes to build).",
+             "can take several minutes to build).",
     )
 
 
@@ -33,8 +38,75 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_slow)
 
 
-@pytest.fixture(scope="session")
-def sky130_pdk():
-    """The sky130 MappedPDK instance used for layout tests."""
-    from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk
-    return sky130_mapped_pdk
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Print a per-(cell, backend) timing table, plus a gdsfactory-vs-gdstk
+    speedup column computed from matched pairs."""
+    # The test module lives next to this conftest. Load via the file path
+    # directly so we don't need `tests/` to be a package.
+    import importlib.util, pathlib
+    test_file = pathlib.Path(__file__).parent / "test_cells_layout.py"
+    spec = importlib.util.spec_from_file_location("_tests_cells_layout", test_file)
+    if spec is None or spec.loader is None:
+        return
+    # The module is already imported by pytest — use the imported instance so
+    # we see the populated TIMINGS list.
+    import sys
+    mod = None
+    for m in sys.modules.values():
+        if getattr(m, "__file__", None) == str(test_file):
+            mod = m
+            break
+    if mod is None or not hasattr(mod, "TIMINGS"):
+        return
+    TIMINGS = mod.TIMINGS
+    if not TIMINGS:
+        return
+
+    # group by test_id -> {backend: row}
+    by_id: dict[str, dict[str, dict]] = {}
+    for row in TIMINGS:
+        by_id.setdefault(row["test_id"], {})[row["backend"]] = row
+
+    tw = terminalreporter
+    tw.write_sep("=", "cell layout build times")
+    header = f"{'cell':<42} {'gdstk (s)':>10} {'gdsfactory (s)':>15} {'speedup':>10} {'status':>20}"
+    tw.write_line(header)
+    tw.write_line("-" * len(header))
+
+    def _fmt(val):
+        return f"{val:.3f}" if isinstance(val, (int, float)) else "—"
+
+    gdstk_total = 0.0
+    gf_total = 0.0
+    paired = 0
+    for tid in sorted(by_id):
+        rows = by_id[tid]
+        gdstk = rows.get("gdstk")
+        gf = rows.get("gdsfactory")
+        t_gdstk = gdstk["elapsed_s"] if gdstk else None
+        t_gf = gf["elapsed_s"] if gf else None
+        if isinstance(t_gdstk, (int, float)) and isinstance(t_gf, (int, float)) and t_gdstk > 0 and gdstk["status"] == "ok" and gf["status"] == "ok":
+            speedup = f"{t_gf / t_gdstk:.2f}x"
+            gdstk_total += t_gdstk
+            gf_total += t_gf
+            paired += 1
+        else:
+            speedup = "—"
+        status_parts = []
+        for name, r in (("gdstk", gdstk), ("gdsfactory", gf)):
+            if r is None:
+                status_parts.append(f"{name}:skip")
+            else:
+                status_parts.append(f"{name}:{r['status']}")
+        tw.write_line(
+            f"{tid:<42} {_fmt(t_gdstk):>10} {_fmt(t_gf):>15} {speedup:>10}"
+            f"   {'/'.join(status_parts)}"
+        )
+
+    if paired:
+        tw.write_line("-" * len(header))
+        tw.write_line(
+            f"{'TOTAL (paired ok)':<42} {_fmt(gdstk_total):>10} "
+            f"{_fmt(gf_total):>15} {(gf_total / gdstk_total):>9.2f}x   "
+            f"{paired} cells"
+        )

--- a/tests/test_cells_layout.py
+++ b/tests/test_cells_layout.py
@@ -1,27 +1,34 @@
 """Layout-generation tests for every cell defined under src/glayout/cells.
 
-Each cell is invoked with a minimum viable argument set and checked for:
-  1. Returns a layout object (Component, or ComponentReference / tuple that
-     can be placed inside a Component).
-  2. Produces a non-empty bounding box.
-  3. Writes a readable GDS file.
+Each test builds one (cell, backend) combination in an isolated subprocess
+and asserts:
+  1. The generator returns a layout that yields a non-empty bounding box.
+  2. A GDS is written and has non-zero size.
+Plus the wall-clock build time is captured for both backends so we can track
+the speedup from the gdstk migration.
 
-Cells that hit pre-existing bugs (unrelated to the layout engine) are marked
-xfail with the failing traceback summary. If any such cell unexpectedly
-starts passing, pytest will surface it as XPASS — a signal to flip the marker.
-
-Heavyweight cells that take several minutes to build are marked `slow` and
-skipped unless `--runslow` is passed.
+Known-broken cells (pre-existing bugs, not migration regressions) are marked
+`xfail` with the failing traceback summary. Heavyweight cells that take
+minutes to build are marked `slow` and skipped unless `--runslow` is passed.
 """
 from __future__ import annotations
 
-import importlib
+import json
 import os
-import tempfile
-from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
 
 import pytest
+
+
+BACKENDS = ("gdstk", "gdsfactory")
+
+# Per-run timing table. Populated by each test and printed by the
+# pytest_terminal_summary hook in conftest.py.
+TIMINGS: list[dict] = []
 
 
 # ---------------------------------------------------------------------------
@@ -31,142 +38,102 @@ import pytest
 
 @dataclass
 class CellCase:
-    """One row of the cell-layout test matrix."""
     test_id: str
     module: str
     func: str
-    # Builder receives the session pdk fixture and returns the kwargs dict.
-    # We use a callable (not a static dict) so the pdk can be injected lazily.
-    kwargs: Callable[[Any], dict]
-    xfail: Optional[str] = None       # reason string; None means expected-pass
-    slow: bool = False                # requires --runslow
+    # Static kwargs. `pdk` is injected inside the subprocess so the object
+    # doesn't need to cross process boundaries.
+    kwargs: dict
+    xfail: Optional[str] = None
+    slow: bool = False
 
 
 CASES: list[CellCase] = [
     # --- elementary ---
-    CellCase(
-        "fvf",
-        "glayout.cells.elementary.FVF.fvf",
-        "flipped_voltage_follower",
-        lambda pdk: {"pdk": pdk},
-    ),
-    CellCase(
-        "current_mirror",
-        "glayout.cells.elementary.current_mirror.current_mirror",
-        "current_mirror",
-        lambda pdk: {"pdk": pdk},
-    ),
-    CellCase(
-        "diff_pair",
-        "glayout.cells.elementary.diff_pair.diff_pair",
-        "diff_pair",
-        lambda pdk: {"pdk": pdk},
-    ),
-    CellCase(
-        "transmission_gate",
-        "glayout.cells.elementary.transmission_gate.transmission_gate",
-        "transmission_gate",
-        lambda pdk: {"pdk": pdk},
-    ),
+    CellCase("fvf",
+             "glayout.cells.elementary.FVF.fvf",
+             "flipped_voltage_follower",
+             {}),
+    CellCase("current_mirror",
+             "glayout.cells.elementary.current_mirror.current_mirror",
+             "current_mirror",
+             {}),
+    CellCase("diff_pair",
+             "glayout.cells.elementary.diff_pair.diff_pair",
+             "diff_pair",
+             {}),
+    CellCase("transmission_gate",
+             "glayout.cells.elementary.transmission_gate.transmission_gate",
+             "transmission_gate",
+             {}),
 
     # --- composite ---
-    CellCase(
-        "differential_to_single_ended_converter",
-        "glayout.cells.composite.differential_to_single_ended_converter.differential_to_single_ended_converter",
-        "differential_to_single_ended_converter",
-        lambda pdk: {"pdk": pdk, "rmult": 1, "half_pload": (0.5, 0.18, 4), "via_xlocation": 10},
-    ),
-    CellCase(
-        "diff_pair_ibias",
-        "glayout.cells.composite.diffpair_cmirror_bias.diff_pair_cmirrorbias",
-        "diff_pair_ibias",
-        lambda pdk: {
-            "pdk": pdk,
-            "half_diffpair_params": (4, 2, 1),
-            "diffpair_bias": (3, 0.15, 1),
-            "rmult": 1,
-            "with_antenna_diode_on_diffinputs": 0,
-        },
-        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
-    ),
-    CellCase(
-        "low_voltage_cmirror_fvf",
-        "glayout.cells.composite.fvf_based_ota.low_voltage_cmirror",
-        "low_voltage_cmirror",
-        lambda pdk: {"pdk": pdk},
-        xfail="pre-existing netlist bug: 'str' object has no attribute 'nodes'",
-    ),
-    CellCase(
-        "n_block",
-        "glayout.cells.composite.fvf_based_ota.n_block",
-        "n_block",
-        lambda pdk: {"pdk": pdk},
-        xfail="pre-existing netlist bug: 'str' object has no attribute 'nodes'",
-        slow=True,
-    ),
-    CellCase(
-        "super_class_AB_OTA",
-        "glayout.cells.composite.fvf_based_ota.ota",
-        "super_class_AB_OTA",
-        lambda pdk: {"pdk": pdk},
-        xfail="pre-existing: builds on n_block which has a netlist bug",
-        slow=True,
-    ),
-    CellCase(
-        "p_block",
-        "glayout.cells.composite.fvf_based_ota.p_block",
-        "p_block",
-        lambda pdk: {"pdk": pdk},
-        xfail="pre-existing: UnboundLocalError on substrate_tap_ref",
-    ),
-    CellCase(
-        "low_voltage_cmirror_standalone",
-        "glayout.cells.composite.low_voltage_cmirror.low_voltage_cmirror",
-        "low_voltage_cmirror",
-        lambda pdk: {"pdk": pdk},
-        xfail="pre-existing: KeyError on ref.info['netlist']",
-    ),
-    CellCase(
-        "diff_pair_stackedcmirror",
-        "glayout.cells.composite.opamp.diff_pair_stackedcmirror",
-        "diff_pair_stackedcmirror",
-        lambda pdk: {
-            "pdk": pdk,
-            "half_diffpair_params": (4, 2, 8),
-            "diffpair_bias": (6, 2, 3),
-            "half_common_source_nbias": (2, 1, 5, 4),
-            "rmult": 2,
-            "with_antenna_diode_on_diffinputs": 7,
-        },
-        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
-    ),
-    CellCase(
-        "opamp",
-        "glayout.cells.composite.opamp.opamp",
-        "opamp",
-        lambda pdk: {"pdk": pdk},
-        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
-        slow=True,
-    ),
-    CellCase(
-        "opamp_twostage",
-        "glayout.cells.composite.opamp.opamp_twostage",
-        "opamp_twostage",
-        lambda pdk: {"pdk": pdk},
-        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
-        slow=True,
-    ),
-    CellCase(
-        "stacked_nfet_current_mirror",
-        "glayout.cells.composite.stacked_current_mirror.stacked_current_mirror",
-        "stacked_nfet_current_mirror",
-        lambda pdk: {
-            "pdk": pdk,
-            "half_common_source_nbias": (4, 2, 4, 4),
-            "rmult": 2,
-            "sd_route_left": True,
-        },
-    ),
+    CellCase("differential_to_single_ended_converter",
+             "glayout.cells.composite.differential_to_single_ended_converter.differential_to_single_ended_converter",
+             "differential_to_single_ended_converter",
+             {"rmult": 1, "half_pload": [0.5, 0.18, 4], "via_xlocation": 10}),
+    CellCase("diff_pair_ibias",
+             "glayout.cells.composite.diffpair_cmirror_bias.diff_pair_cmirrorbias",
+             "diff_pair_ibias",
+             {"half_diffpair_params": [4, 2, 1],
+              "diffpair_bias": [3, 0.15, 1],
+              "rmult": 1,
+              "with_antenna_diode_on_diffinputs": 0},
+             xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg"),
+    CellCase("low_voltage_cmirror_fvf",
+             "glayout.cells.composite.fvf_based_ota.low_voltage_cmirror",
+             "low_voltage_cmirror",
+             {},
+             xfail="pre-existing netlist bug: 'str' object has no attribute 'nodes'"),
+    CellCase("n_block",
+             "glayout.cells.composite.fvf_based_ota.n_block",
+             "n_block",
+             {},
+             xfail="pre-existing netlist bug: 'str' object has no attribute 'nodes'",
+             slow=True),
+    CellCase("super_class_AB_OTA",
+             "glayout.cells.composite.fvf_based_ota.ota",
+             "super_class_AB_OTA",
+             {},
+             xfail="pre-existing: builds on n_block which has a netlist bug",
+             slow=True),
+    CellCase("p_block",
+             "glayout.cells.composite.fvf_based_ota.p_block",
+             "p_block",
+             {},
+             xfail="pre-existing: UnboundLocalError on substrate_tap_ref"),
+    CellCase("low_voltage_cmirror_standalone",
+             "glayout.cells.composite.low_voltage_cmirror.low_voltage_cmirror",
+             "low_voltage_cmirror",
+             {},
+             xfail="pre-existing: KeyError on ref.info['netlist']"),
+    CellCase("diff_pair_stackedcmirror",
+             "glayout.cells.composite.opamp.diff_pair_stackedcmirror",
+             "diff_pair_stackedcmirror",
+             {"half_diffpair_params": [4, 2, 8],
+              "diffpair_bias": [6, 2, 3],
+              "half_common_source_nbias": [2, 1, 5, 4],
+              "rmult": 2,
+              "with_antenna_diode_on_diffinputs": 7},
+             xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg"),
+    CellCase("opamp",
+             "glayout.cells.composite.opamp.opamp",
+             "opamp",
+             {},
+             xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
+             slow=True),
+    CellCase("opamp_twostage",
+             "glayout.cells.composite.opamp.opamp_twostage",
+             "opamp_twostage",
+             {},
+             xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
+             slow=True),
+    CellCase("stacked_nfet_current_mirror",
+             "glayout.cells.composite.stacked_current_mirror.stacked_current_mirror",
+             "stacked_nfet_current_mirror",
+             {"half_common_source_nbias": [4, 2, 4, 4],
+              "rmult": 2,
+              "sd_route_left": True}),
 ]
 
 
@@ -175,84 +142,116 @@ CASES: list[CellCase] = [
 # ---------------------------------------------------------------------------
 
 
-def _materialize(result) -> "Component":
-    """Accept whatever a cell returns and return a Component that owns the
-    geometry, so downstream checks (bbox, write_gds) have a single code path.
-
-    Covers:
-      - Component: return as-is.
-      - ComponentReference: wrap in a fresh Component and add the ref.
-      - tuple/list: wrap all ref/Component items in a fresh parent.
-    """
-    from glayout.backend import Component, ComponentReference
-
-    if isinstance(result, Component):
-        return result
-
-    wrapper = Component("test_wrapper")
-
-    if isinstance(result, ComponentReference):
-        wrapper.add(result)
-        return wrapper
-
-    if isinstance(result, (tuple, list)):
-        added = False
-        for item in result:
-            if isinstance(item, ComponentReference):
-                wrapper.add(item)
-                added = True
-            elif isinstance(item, Component):
-                wrapper.add(wrapper << item)
-                added = True
-        if not added:
-            raise AssertionError(
-                f"cell returned a tuple with no Component/ComponentReference: {result!r}"
-            )
-        return wrapper
-
-    raise AssertionError(f"unexpected return type {type(result).__name__}")
+def _backend_available(name: str) -> bool:
+    if name == "gdstk":
+        try:
+            import gdstk  # noqa: F401
+            return True
+        except ImportError:
+            return False
+    if name == "gdsfactory":
+        try:
+            import gdsfactory  # noqa: F401
+            return True
+        except ImportError:
+            return False
+    return False
 
 
-def _case_marks(case: CellCase):
-    marks = []
-    if case.slow:
-        marks.append(pytest.mark.slow)
-    return marks
+_SRC = str(Path(__file__).resolve().parents[1] / "src")
+_WORKER = str(Path(__file__).resolve().parent / "_cell_worker.py")
+
+
+def _run_worker(case: CellCase, backend: str, timeout_s: int = 600) -> dict:
+    """Invoke the cell in an isolated subprocess with the chosen backend.
+    Returns the parsed JSON result (or an error dict on timeout / bad exit)."""
+    env = os.environ.copy()
+    env["GLAYOUT_BACKEND"] = backend
+    env["PYTHONPATH"] = _SRC + os.pathsep + env.get("PYTHONPATH", "")
+    env.setdefault("PDK_ROOT", "/tmp")
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, _WORKER, case.module, case.func, json.dumps(case.kwargs)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "elapsed_s": timeout_s,
+                "error": f"timed out after {timeout_s}s"}
+
+    # Workers print a single JSON line on stdout. Tolerate trailing output.
+    payload: Optional[dict] = None
+    for line in reversed(proc.stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                payload = json.loads(line)
+                break
+            except json.JSONDecodeError:
+                continue
+
+    if payload is None:
+        return {
+            "status": "error",
+            "elapsed_s": 0.0,
+            "error": f"worker produced no JSON; exit={proc.returncode}",
+            "stdout": proc.stdout[-2000:],
+            "stderr": proc.stderr[-2000:],
+        }
+    return payload
 
 
 # ---------------------------------------------------------------------------
-# Test
+# Parametrized test
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "case",
-    [pytest.param(c, id=c.test_id, marks=_case_marks(c)) for c in CASES],
-)
-def test_cell_builds_layout(sky130_pdk, case: CellCase):
-    """Build the cell, verify its layout, and round-trip it through a GDS file."""
-    if case.xfail:
-        pytest.xfail(case.xfail)
+def _params() -> list:
+    out = []
+    for case in CASES:
+        for backend in BACKENDS:
+            marks = []
+            if case.slow:
+                marks.append(pytest.mark.slow)
+            if case.xfail:
+                marks.append(pytest.mark.xfail(reason=case.xfail, strict=False))
+            out.append(pytest.param(case, backend,
+                                    id=f"{case.test_id}-{backend}",
+                                    marks=marks))
+    return out
 
-    import gdstk
 
-    mod = importlib.import_module(case.module)
-    func = getattr(mod, case.func)
-    raw = func(**case.kwargs(sky130_pdk))
+@pytest.mark.parametrize("case,backend", _params())
+def test_cell_builds_layout(case: CellCase, backend: str):
+    """Build the cell with the selected backend and verify the layout."""
+    if not _backend_available(backend):
+        pytest.skip(f"{backend} backend not installed")
 
-    component = _materialize(raw)
+    result = _run_worker(case, backend, timeout_s=900 if case.slow else 180)
 
-    (x0, y0), (x1, y1) = component.bbox
+    # Always record timing so skipped / xfailed cells still show up in the
+    # summary — useful for tracking speedups even on failing cells.
+    TIMINGS.append({
+        "test_id": case.test_id,
+        "backend": backend,
+        "status": result.get("status"),
+        "elapsed_s": result.get("elapsed_s"),
+        "gds_bytes": result.get("gds_bytes"),
+        "error": result.get("error"),
+    })
+
+    if result["status"] != "ok":
+        pytest.fail(
+            f"{case.test_id}/{backend} failed: {result.get('error')}\n"
+            f"{result.get('traceback', '')}"
+        )
+
+    bbox = result["bbox"]
+    (x0, y0), (x1, y1) = bbox
     assert (x1 - x0) > 0 and (y1 - y0) > 0, (
-        f"{case.test_id}: layout has empty bounding box {component.bbox}"
+        f"{case.test_id}/{backend}: empty bbox {bbox}"
     )
-
-    with tempfile.TemporaryDirectory() as td:
-        path = os.path.join(td, f"{case.test_id}.gds")
-        component.write_gds(path)
-        assert os.path.isfile(path), f"{case.test_id}: GDS file was not created"
-        assert os.path.getsize(path) > 0, f"{case.test_id}: GDS file is empty"
-
-        # Round-trip: the file must be parseable by gdstk and contain cells.
-        lib = gdstk.read_gds(path)
-        assert lib.cells, f"{case.test_id}: GDS file has no cells"
+    assert result["gds_bytes"] > 0, f"{case.test_id}/{backend}: empty GDS"

--- a/tests/test_cells_layout.py
+++ b/tests/test_cells_layout.py
@@ -1,0 +1,258 @@
+"""Layout-generation tests for every cell defined under src/glayout/cells.
+
+Each cell is invoked with a minimum viable argument set and checked for:
+  1. Returns a layout object (Component, or ComponentReference / tuple that
+     can be placed inside a Component).
+  2. Produces a non-empty bounding box.
+  3. Writes a readable GDS file.
+
+Cells that hit pre-existing bugs (unrelated to the layout engine) are marked
+xfail with the failing traceback summary. If any such cell unexpectedly
+starts passing, pytest will surface it as XPASS — a signal to flip the marker.
+
+Heavyweight cells that take several minutes to build are marked `slow` and
+skipped unless `--runslow` is passed.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Case table
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CellCase:
+    """One row of the cell-layout test matrix."""
+    test_id: str
+    module: str
+    func: str
+    # Builder receives the session pdk fixture and returns the kwargs dict.
+    # We use a callable (not a static dict) so the pdk can be injected lazily.
+    kwargs: Callable[[Any], dict]
+    xfail: Optional[str] = None       # reason string; None means expected-pass
+    slow: bool = False                # requires --runslow
+
+
+CASES: list[CellCase] = [
+    # --- elementary ---
+    CellCase(
+        "fvf",
+        "glayout.cells.elementary.FVF.fvf",
+        "flipped_voltage_follower",
+        lambda pdk: {"pdk": pdk},
+    ),
+    CellCase(
+        "current_mirror",
+        "glayout.cells.elementary.current_mirror.current_mirror",
+        "current_mirror",
+        lambda pdk: {"pdk": pdk},
+    ),
+    CellCase(
+        "diff_pair",
+        "glayout.cells.elementary.diff_pair.diff_pair",
+        "diff_pair",
+        lambda pdk: {"pdk": pdk},
+    ),
+    CellCase(
+        "transmission_gate",
+        "glayout.cells.elementary.transmission_gate.transmission_gate",
+        "transmission_gate",
+        lambda pdk: {"pdk": pdk},
+    ),
+
+    # --- composite ---
+    CellCase(
+        "differential_to_single_ended_converter",
+        "glayout.cells.composite.differential_to_single_ended_converter.differential_to_single_ended_converter",
+        "differential_to_single_ended_converter",
+        lambda pdk: {"pdk": pdk, "rmult": 1, "half_pload": (0.5, 0.18, 4), "via_xlocation": 10},
+    ),
+    CellCase(
+        "diff_pair_ibias",
+        "glayout.cells.composite.diffpair_cmirror_bias.diff_pair_cmirrorbias",
+        "diff_pair_ibias",
+        lambda pdk: {
+            "pdk": pdk,
+            "half_diffpair_params": (4, 2, 1),
+            "diffpair_bias": (3, 0.15, 1),
+            "rmult": 1,
+            "with_antenna_diode_on_diffinputs": 0,
+        },
+        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
+    ),
+    CellCase(
+        "low_voltage_cmirror_fvf",
+        "glayout.cells.composite.fvf_based_ota.low_voltage_cmirror",
+        "low_voltage_cmirror",
+        lambda pdk: {"pdk": pdk},
+        xfail="pre-existing netlist bug: 'str' object has no attribute 'nodes'",
+    ),
+    CellCase(
+        "n_block",
+        "glayout.cells.composite.fvf_based_ota.n_block",
+        "n_block",
+        lambda pdk: {"pdk": pdk},
+        xfail="pre-existing netlist bug: 'str' object has no attribute 'nodes'",
+        slow=True,
+    ),
+    CellCase(
+        "super_class_AB_OTA",
+        "glayout.cells.composite.fvf_based_ota.ota",
+        "super_class_AB_OTA",
+        lambda pdk: {"pdk": pdk},
+        xfail="pre-existing: builds on n_block which has a netlist bug",
+        slow=True,
+    ),
+    CellCase(
+        "p_block",
+        "glayout.cells.composite.fvf_based_ota.p_block",
+        "p_block",
+        lambda pdk: {"pdk": pdk},
+        xfail="pre-existing: UnboundLocalError on substrate_tap_ref",
+    ),
+    CellCase(
+        "low_voltage_cmirror_standalone",
+        "glayout.cells.composite.low_voltage_cmirror.low_voltage_cmirror",
+        "low_voltage_cmirror",
+        lambda pdk: {"pdk": pdk},
+        xfail="pre-existing: KeyError on ref.info['netlist']",
+    ),
+    CellCase(
+        "diff_pair_stackedcmirror",
+        "glayout.cells.composite.opamp.diff_pair_stackedcmirror",
+        "diff_pair_stackedcmirror",
+        lambda pdk: {
+            "pdk": pdk,
+            "half_diffpair_params": (4, 2, 8),
+            "diffpair_bias": (6, 2, 3),
+            "half_common_source_nbias": (2, 1, 5, 4),
+            "rmult": 2,
+            "with_antenna_diode_on_diffinputs": 7,
+        },
+        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
+    ),
+    CellCase(
+        "opamp",
+        "glayout.cells.composite.opamp.opamp",
+        "opamp",
+        lambda pdk: {"pdk": pdk},
+        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
+        slow=True,
+    ),
+    CellCase(
+        "opamp_twostage",
+        "glayout.cells.composite.opamp.opamp_twostage",
+        "opamp_twostage",
+        lambda pdk: {"pdk": pdk},
+        xfail="pre-existing: current_mirror_interdigitized_netlist() missing 'fingers' arg",
+        slow=True,
+    ),
+    CellCase(
+        "stacked_nfet_current_mirror",
+        "glayout.cells.composite.stacked_current_mirror.stacked_current_mirror",
+        "stacked_nfet_current_mirror",
+        lambda pdk: {
+            "pdk": pdk,
+            "half_common_source_nbias": (4, 2, 4, 4),
+            "rmult": 2,
+            "sd_route_left": True,
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _materialize(result) -> "Component":
+    """Accept whatever a cell returns and return a Component that owns the
+    geometry, so downstream checks (bbox, write_gds) have a single code path.
+
+    Covers:
+      - Component: return as-is.
+      - ComponentReference: wrap in a fresh Component and add the ref.
+      - tuple/list: wrap all ref/Component items in a fresh parent.
+    """
+    from glayout.backend import Component, ComponentReference
+
+    if isinstance(result, Component):
+        return result
+
+    wrapper = Component("test_wrapper")
+
+    if isinstance(result, ComponentReference):
+        wrapper.add(result)
+        return wrapper
+
+    if isinstance(result, (tuple, list)):
+        added = False
+        for item in result:
+            if isinstance(item, ComponentReference):
+                wrapper.add(item)
+                added = True
+            elif isinstance(item, Component):
+                wrapper.add(wrapper << item)
+                added = True
+        if not added:
+            raise AssertionError(
+                f"cell returned a tuple with no Component/ComponentReference: {result!r}"
+            )
+        return wrapper
+
+    raise AssertionError(f"unexpected return type {type(result).__name__}")
+
+
+def _case_marks(case: CellCase):
+    marks = []
+    if case.slow:
+        marks.append(pytest.mark.slow)
+    return marks
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case",
+    [pytest.param(c, id=c.test_id, marks=_case_marks(c)) for c in CASES],
+)
+def test_cell_builds_layout(sky130_pdk, case: CellCase):
+    """Build the cell, verify its layout, and round-trip it through a GDS file."""
+    if case.xfail:
+        pytest.xfail(case.xfail)
+
+    import gdstk
+
+    mod = importlib.import_module(case.module)
+    func = getattr(mod, case.func)
+    raw = func(**case.kwargs(sky130_pdk))
+
+    component = _materialize(raw)
+
+    (x0, y0), (x1, y1) = component.bbox
+    assert (x1 - x0) > 0 and (y1 - y0) > 0, (
+        f"{case.test_id}: layout has empty bounding box {component.bbox}"
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, f"{case.test_id}.gds")
+        component.write_gds(path)
+        assert os.path.isfile(path), f"{case.test_id}: GDS file was not created"
+        assert os.path.getsize(path) > 0, f"{case.test_id}: GDS file is empty"
+
+        # Round-trip: the file must be parseable by gdstk and contain cells.
+        lib = gdstk.read_gds(path)
+        assert lib.cells, f"{case.test_id}: GDS file has no cells"

--- a/tests/test_gdstk_backend.py
+++ b/tests/test_gdstk_backend.py
@@ -1,0 +1,70 @@
+"""End-to-end sanity for the gdstk backend: import, build, write GDS."""
+import os
+import tempfile
+import unittest
+
+
+class GdstkBackendTests(unittest.TestCase):
+    """Run with GLAYOUT_BACKEND=gdstk. These tests verify that the native
+    gdstk backend can build the primitives and routers the repo exposes."""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ["GLAYOUT_BACKEND"] = "gdstk"
+        os.environ.setdefault("PDK_ROOT", "/tmp")
+        # Force (re)binding in case the selector was imported earlier.
+        from glayout import backend
+        backend.set_backend("gdstk")
+
+    def test_backend_selected(self):
+        from glayout import backend
+        self.assertEqual(backend.get_backend(), "gdstk")
+
+    def test_component_api(self):
+        from glayout.backend import Component, Port, rectangle
+        c = Component("probe")
+        r = rectangle(size=(5, 3), layer=(1, 0))
+        ref = c << r
+        ref.movex(10)
+        self.assertEqual(c.bbox, ((10.0, 0.0), (15.0, 3.0)))
+        c.add_port(name="p1", center=(0, 0), width=1, orientation=0, layer=(1, 0))
+        self.assertIn("p1", c.ports)
+
+    def test_primitives_build(self):
+        from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk as pdk
+        from glayout.primitives.via_gen import via_stack, via_array
+        from glayout.primitives.fet import nmos, pmos
+        from glayout.primitives.guardring import tapring
+        self.assertIsNotNone(via_stack(pdk, "active_diff", "met2").bbox)
+        self.assertIsNotNone(via_array(pdk, "active_diff", "met2", num_vias=(2, 3)).bbox)
+        self.assertIsNotNone(nmos(pdk, fingers=1).bbox)
+        self.assertIsNotNone(pmos(pdk, fingers=1).bbox)
+        self.assertIsNotNone(tapring(pdk).bbox)
+
+    def test_routing_build(self):
+        from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk as pdk
+        from glayout.backend import Port
+        from glayout.routing.c_route import c_route
+        from glayout.routing.L_route import L_route
+        from glayout.routing.straight_route import straight_route
+        layer = pdk.get_glayer("met2")
+        pa = Port("a", orientation=90, center=(0, 0), width=1, layer=layer)
+        pb = Port("b", orientation=90, center=(10, 0), width=1, layer=layer)
+        pc = Port("c", orientation=270, center=(0, 10), width=1, layer=layer)
+        pd = Port("d", orientation=0, center=(10, 10), width=1, layer=pdk.get_glayer("met5"))
+        self.assertIsNotNone(c_route(pdk, pa, pb, extension=2).bbox)
+        self.assertIsNotNone(L_route(pdk, pa, pd).bbox)
+        self.assertIsNotNone(straight_route(pdk, pa, pc).bbox)
+
+    def test_composite_diff_pair_writes_gds(self):
+        from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk as pdk
+        from glayout.cells.elementary.diff_pair.diff_pair import diff_pair
+        dp = diff_pair(pdk)
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "dp.gds")
+            dp.write_gds(path)
+            self.assertGreater(os.path.getsize(path), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
!!! Note: This PR depends on #88 !!!

Replacing all `gdsfactory` references with a new `glayout.backend` module. This is a intermediate layer that selects one of four backends at PDK-activate time. All four modes share exactly the same API interface, and produce byte-identical GDS across the 18 CI cells (9 sky130 + 9 gf180). DRC 18/18 pass; LVS 15/16 (the gf180 opamp fail is pre-existing on `main`).

| mode | sky130 | gf180 | runtime gdsfactory |
|---|---|---|---|
| `vanilla` | 35.1 s | 28.9 s | yes (no patches) |
| `gdstk` | 3.94 s | 3.40 s | **no** |
| `gdstk_cython` | 3.43 s | 2.85 s | **no** |
| `native` (default) | 1.63 s | 1.36 s | yes (+ monkey-patches) |

Numbers are 3-rep median of the 9-cell wall-clock benchmark (`benchmark/bench_cells_wallclock.py`) inside `iic-osic-tools` docker.


**`native` mode** — gdsfactory with hot-path patches installed at `MappedPDK.activate()` time: fast `Port.__init__`/`copy`, fast `Component.add_port`/`add_ports`/`flatten` (with shallow-share for no-prefix Mapping), `ComponentReference.ports` cache + identity-share, PDK method memoization, `assert_ports_on_grid` no-op, `@validate_arguments` stripped from glayout modules, and dropping the `via_array.array_` port set (no caller reads it).

**`gdstk` mode** — pure-Python `_NativeComponent` / `_NativeComponentReference` / `_NativePort` (`@dataclass(slots=True)`) wrapping `gdstk.Cell` directly. Swapped in at activate time. Custom `@cell` decorator handles the sky130 `default_decorator` + `clear_cache` semantics. Closed the gdsfactory-mode gap via slots, a lazy `_RefPortsList` that lets `add_ports(ref.get_ports_list(), prefix=...)` skip its double-allocation, cardinal-rotation exact math, `snap_to_grid` skip-on-no-refs.

**`gdstk_cython` mode** — same Python `_NativeComponent`/`_NativeComponentReference` but with `_CyPort` (cdef class, `cdef public` fields) swapped in for `_NativePort`. Built via `pyproject.toml` + `setup.py`'s `cythonize(...)`. Cdef hot-loop helpers exist (`cy_add_ports_from_ref`, `cy_build_transformed_ports`) but are not wired — they trip a ~770 nm transform drift under load that I couldn't pin down.