### PR TITLE
Fix order-dependent port renaming; close gdstk backend gaps

### DIFF
--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -576,6 +576,19 @@ class Component:
             self.ports[new_name] = np
         return self
 
+    def pprint_ports(self) -> None:
+        """Print the ports, one per line.
+
+        gdsfactory offers this on Component and the tutorials use it to look
+        at a cell while building it. Without it a notebook that runs fine on
+        the other backend dies with AttributeError halfway through.
+        """
+        for name in sorted(self.ports):
+            p = self.ports[name]
+            print("%-42s (%9.3f, %9.3f)  ancho %7.3f  %5.1f  %s"
+                  % (name, p.center[0], p.center[1], p.width,
+                     p.orientation or 0.0, p.layer))
+
     def get_ports_list(self, prefix: str = "", **filters) -> list[Port]:
         out: list[Port] = []
         for name, p in self.ports.items():

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -264,8 +264,22 @@ class ComponentReference:
         self._ref = gref
         # owner is the Component this reference has been added to (not the target)
         self.owner: Optional["Component"] = None
-        # `info` is used by some cells to attach netlist / hierarchy metadata.
-        self.info: dict = {}
+
+    # --- metadata ----------------------------------------------------------
+    @property
+    def info(self) -> dict:
+        """Metadata of the referenced component.
+
+        gdsfactory exposes the parent's `info` through the reference, and cells
+        rely on that: mimcap_array writes `info['netlist']` on the Component,
+        while opamp_twostage reads it back off the reference returned by `<<`.
+        A reference has no metadata of its own, so delegate.
+        """
+        return self.parent.info
+
+    @info.setter
+    def info(self, value: dict) -> None:
+        self.parent.info = value
 
     # --- transform properties ---------------------------------------------
     @property
@@ -477,13 +491,17 @@ class Component:
 
     def add(
         self,
-        element: Union[ComponentReference, gdstk.Reference, gdstk.Polygon, gdstk.Label, Iterable],
+        element: Union["Component", ComponentReference, gdstk.Reference, gdstk.Polygon, gdstk.Label, Iterable],
     ) -> "Component":
-        """Add a reference, polygon, label, or iterable of those."""
+        """Add a component, reference, polygon, label, or iterable of those."""
         if isinstance(element, ComponentReference):
             self._cell.add(element._ref)
             element.owner = self
             self._references.append(element)
+        elif isinstance(element, Component):
+            # gdsfactory accepts a bare Component here and references it
+            # implicitly; opamp_twostage and others rely on that.
+            self.add_ref(element)
         elif isinstance(element, (gdstk.Reference, gdstk.Polygon, gdstk.Label)):
             self._cell.add(element)
         elif isinstance(element, Iterable):
@@ -493,10 +511,26 @@ class Component:
             raise TypeError(f"Component.add: unsupported type {type(element).__name__}")
         return self
 
-    def ref(self) -> ComponentReference:
+    def ref(
+        self,
+        position: Coord = (0.0, 0.0),
+        rotation: float = 0.0,
+        x_reflection: bool = False,
+    ) -> ComponentReference:
         """Return a fresh ComponentReference pointing at this Component.
-        Not yet attached to any parent."""
-        return ComponentReference(self)
+
+        Not yet attached to any parent. `position`, `rotation` and
+        `x_reflection` mirror gdsfactory's signature; opamp.py calls
+        `rect.ref(position=...)`.
+        """
+        r = ComponentReference(self)
+        if x_reflection:
+            r.mirror(p1=(0.0, 0.0), p2=(1.0, 0.0))
+        if rotation:
+            r.rotate(rotation)
+        if position != (0.0, 0.0):
+            r.movex(position[0]).movey(position[1])
+        return r
 
     # --- ports -------------------------------------------------------------
     def add_port(

--- a/src/glayout/cells/composite/opamp/diff_pair_stackedcmirror.py
+++ b/src/glayout/cells/composite/opamp/diff_pair_stackedcmirror.py
@@ -76,7 +76,10 @@ def __route_bottom_ncomps_except_drain_nbias(pdk: MappedPDK, toplevel_stacked: C
     # leaving a sliver gap that trips m2.2a. Stamp an m2 patch at each
     # corner that overlaps both polygons so they merge in DRC.
     if pdk.name.lower() == "gf180":
-        from gdsfactory.components.rectangle import rectangle as _rect
+        # use the backend's rectangle (already imported at module level), not
+        # gdsfactory's: importing it directly bypasses the backend abstraction
+        # and yields a component the active backend cannot reference.
+        _rect = rectangle
         _m2 = pdk.get_glayer("met2")
         # Use cmirror_ref_L's drain_E port (center.x is the inner edge of
         # cmirror_ref_L's leftmost drain column on m2; mirror for R) and

--- a/src/glayout/util/port_utils.py
+++ b/src/glayout/util/port_utils.py
@@ -124,22 +124,24 @@ def rename_component_ports(custom_comp: Union[Component, ComponentReference], re
     if you want to pass additional args to rename_function, implement a functor
     custom_comp is the components to modify. the modified component is returned
     """
-    names_to_modify = list()
-    # find ports and get new names
-    for pname, pobj in custom_comp.ports.items():
+    # Build the renamed mapping first, then swap it in.
+    #
+    # Renaming in place (pop old key, insert new key on the same dict) makes the
+    # result depend on dict insertion order: when a port renames onto a name that
+    # is still queued for renaming, one of the two is silently dropped, and which
+    # one survives differs between backends. rename_ports_by_orientation is the
+    # common trigger, since a mirrored port legitimately renames _S -> _N onto a
+    # name another port still holds.
+    renamed = dict()
+    for pname, pobj in list(custom_comp.ports.items()):
         # error checking
         if not pname == pobj.name:
             raise ValueError("component may have an invalid ports dict")
         new_name = rename_function(pname, pobj)
-        names_to_modify.append((pname,new_name))
-    # modify names
-    for namepair in names_to_modify:
-        if namepair[0] in custom_comp.ports.keys():
-            portobj = custom_comp.ports.pop(namepair[0])
-            portobj.name = namepair[1]
-            custom_comp.ports[namepair[1]] = portobj
-        else:
-            raise KeyError("name "+str(namepair[0])+" not in component ports")
+        pobj.name = new_name
+        renamed[new_name] = pobj
+    custom_comp.ports.clear()
+    custom_comp.ports.update(renamed)
     # returns modified component/component ref
     return custom_comp
 


### PR DESCRIPTION
Two commits. The first is a real bug in `port_utils` that affects the default
backend too; the second unblocks `GLAYOUT_BACKEND=gdstk` for the opamp.

## Renaming ports depends on dict order

`rename_component_ports` renames in place — pops the old key and inserts the
new one on the same dict it just iterated:

```python
for namepair in names_to_modify:
    if namepair[0] in custom_comp.ports.keys():
        portobj = custom_comp.ports.pop(namepair[0])
        custom_comp.ports[namepair[1]] = portobj
```

When a port renames onto a name another port still holds, that guard silently
skips it and one of the two is dropped. Which one survives depends on insertion
order.

`rename_ports_by_orientation` triggers this routinely: a mirrored port has
orientation 90 and legitimately renames `_S` -> `_N` onto a name still queued.
In `diff_pair(gf180, width=3, fingers=4)` that is **334 ports**.

Same component, same port, orientation 90.0:

| backend | result |
|---|---|
| gdsfactory | keeps `bl_multiplier_0_source_S` (90° is N, so this is wrong) |
| gdstk | gives `bl_multiplier_0_source_N` (correct) |

`add_df_labels` then raises `KeyError` on the latter. It works under gdsfactory
by accident of ordering, not by construction.

Fix builds the renamed mapping first, then swaps it in.

```
diff_pair(gf180, width=3, fingers=4)
  before   4530 ports    gdstk: KeyError 'bl_multiplier_0_source_S'
  after    4864 ports    both backends identical
```

The 334 extra ports are the ones that were being dropped.

## gdstk backend gaps

With the rename fixed, the opamp got further and hit four more gaps, found one
at a time:

1. `Component.add()` rejected a bare `Component`. gdsfactory accepts one and
   references it implicitly; several composite cells rely on that.
2. `diff_pair_stackedcmirror` imported `rectangle` straight from gdsfactory,
   bypassing the backend abstraction — the module already imports the backend's
   `rectangle` at module level.
3. `ComponentReference.info` held its own empty dict. `mimcap_array` writes
   `info['netlist']` on the Component while `opamp_twostage` reads it back off
   the reference returned by `<<`; gdsfactory exposes the parent's info through
   the reference, so delegate.
4. `Component.ref()` took no arguments. `opamp.py:155` calls
   `ref(position=...)`.

## Results

`opamp(gf180, ...)`, same parameters as `GLayout_Cells.ipynb` cell 14:

| backend | time | ports |
|---|---|---|
| gdsfactory | 383.0 s | — |
| gdstk | **55.5 s** | 99090 |

No regression: under `gdsfactory`, `nmos(gf180, width=3, fingers=4)` produces
3328 ports and 875 polygons before and after.

## Note

This makes the fast backend usable; it does not address why the slow one is
slow. Profiling the opamp under `gdsfactory` shows 96% of runtime inside
pydantic validation, 6.3M `serialization.py` calls, and 1.85M `Port` objects
created — 93% of a transistor's ports belong to individual vias that are never
routed to. That is a port-model question, not something a compatibility fix
reaches.
