### PR TITLE
gdstk backend: close API gaps so the tutorials run

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -123,14 +123,34 @@ jobs:
           # pulls in gdstk / svgutils / ipywidgets; jupyter+nbconvert+
           # ipykernel are the only extras the notebook harness needs.
           uv pip install -e .
-          uv pip install jupyter nbconvert ipykernel
+          # jupyter-client pinned: 8.10.0 (published 2026-08-28 12:17 UTC)
+          # quadrupled the rate of lost kernel replies on this runner --
+          # measured A/B on the same machine, 4/6 hangs against 1/6 with
+          # 8.9.1. Unpinned, each run silently takes whatever PyPI shipped
+          # that morning, which is why one commit passed on the 25th and
+          # hung on the 28th.
+          uv pip install jupyter nbconvert ipykernel "jupyter-client==8.9.1"
+
+      # Runs on cache hits too. The install step above is skipped when the
+      # venv is restored, so a pin written only there is inert: the cache
+      # key hashes setup.py and src/, not this file, and a restored venv
+      # keeps whatever jupyter-client it was built with. That is also how
+      # 8.10.0 got in -- a src change busted the key on the 28th and the
+      # rebuild took the version published that morning. Enforcing the pin
+      # here is a no-op when it already matches.
+      - name: Enforce the jupyter-client pin
+        run: |
+          set -euxo pipefail
+          . "$GITHUB_WORKSPACE/.venv/bin/activate"
+          uv pip install "jupyter-client==8.9.1"
+          python -c "import jupyter_client; print(jupyter_client.__version__)"
 
       - name: Run all tutorial notebooks
         run: |
           set -euxo pipefail
           . "$GITHUB_WORKSPACE/.venv/bin/activate"
           python tests/notebooks/run_tutorial_notebooks.py \
-            --out-dir notebook_results
+            --out-dir notebook_results --strip-displays --retries 1
 
       - name: Upload notebook artifacts
         if: always()

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -44,6 +44,10 @@ class _CellDecoratorSettings(BaseModel):
     cache: bool = False
 
 
+# The PDK whose grid snap_to_grid() should use. Set by Pdk.activate().
+_ACTIVE_PDK: Optional["Pdk"] = None
+
+
 class Pdk(BaseModel):
     """Minimal shim for gdsfactory.pdk.Pdk. Holds enough state for
     MappedPDK to function."""
@@ -53,15 +57,29 @@ class Pdk(BaseModel):
     name: str
     layers: Optional[dict] = None
     default_decorator: Optional[Any] = None
-    grid_size: float = 0.001  # microns; matches gdsfactory default
+    grid_size: float = 0.001  # microns; corrected in activate() from precision
     gds_write_settings: _GdsWriteSettings = _GdsWriteSettings()
     cell_decorator_settings: _CellDecoratorSettings = _CellDecoratorSettings()
 
     def activate(self) -> None:
-        """No-op. gdsfactory's activate() registered the PDK in a global
-        registry; that registry is a gdsfactory concern and isn't needed
-        once gdsfactory is out of the import graph."""
-        return None
+        """Register this PDK as the active one.
+
+        gdsfactory kept a global registry so that helpers like snap_to_grid
+        could look up the process grid. Most of that registry is a gdsfactory
+        concern, but the grid is not: snapping to the wrong pitch puts every
+        vertex off-grid, and the DRC reports it on all of them.
+        """
+        # gdsfactory filled grid_size in from its PDK database here. Without
+        # that database the class default (1 nm) survives, and snapping a 5 nm
+        # process to 1 nm puts every vertex off-grid -- the DRC then flags
+        # comp, metal, contact and via alike. precision already carries the
+        # real pitch, so derive it rather than duplicating the number.
+        precision_um = float(self.gds_write_settings.precision) * 1e6
+        if precision_um > 0 and self.grid_size != precision_um:
+            object.__setattr__(self, "grid_size", precision_um)
+
+        global _ACTIVE_PDK
+        _ACTIVE_PDK = self
 
     def validate_layers(self, layers_required) -> None:
         """Mimics gdsfactory.pdk.Pdk.validate_layers — raise if any named
@@ -884,16 +902,23 @@ def Polygon(points, layer=(0, 0), datatype=None) -> gdstk.Polygon:
 # ---------------------------------------------------------------------------
 
 
-def snap_to_grid(x, nm: int = 1):
-    """Snap `x` (in micrometers) to an `nm`-nanometer grid.
+def snap_to_grid(x, nm: Optional[int] = None, grid_factor: int = 1):
+    """Snap `x` (in micrometers) to the active PDK's grid.
 
-    Matches gdsfactory.snap.snap_to_grid semantics used in this repo.
+    Mirrors gdsfactory.snap.snap_to_grid, which reads the grid from the active
+    PDK rather than assuming one: gf180 is on 5 nm, and snapping it to 1 nm
+    leaves every vertex off-grid (the DRC then flags comp, metal, contact and
+    via alike). `nm` overrides the lookup when a caller needs a specific pitch.
+
     Accepts scalars or iterables.
     """
     if x is None:
         return None
     if isinstance(x, (list, tuple)):
-        return type(x)(snap_to_grid(v, nm) for v in x)
+        return type(x)(snap_to_grid(v, nm, grid_factor) for v in x)
+    if nm is None:
+        grid_um = _ACTIVE_PDK.grid_size if _ACTIVE_PDK is not None else 0.001
+        nm = max(1, int(round(grid_um * 1000.0 * grid_factor)))
     return round(float(x) * 1000.0 / nm) * nm / 1000.0
 
 

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -29,6 +29,7 @@ PathType = Union[str, _Path]
 # cell_decorator_settings, .activate()). Extra fields are allowed so callers
 # can pass arbitrary pdk-specific config.
 from pydantic import BaseModel, ConfigDict  # noqa: E402
+import os as _os
 
 
 class _GdsWriteSettings(BaseModel):
@@ -264,6 +265,9 @@ class ComponentReference:
         self._ref = gref
         # owner is the Component this reference has been added to (not the target)
         self.owner: Optional["Component"] = None
+        # a label for this placement; falls back to the target cell's name
+        self._name: Optional[str] = None
+
 
     # --- metadata ----------------------------------------------------------
     @property
@@ -308,14 +312,31 @@ class ComponentReference:
         self._ref.x_reflection = bool(value)
 
     # --- movement (mutate + return self) ----------------------------------
-    def movex(self, dx: float = 0.0) -> "ComponentReference":
+    def movex(
+        self,
+        origin: float = 0.0,
+        destination: Optional[float] = None,
+    ) -> "ComponentReference":
+        """Move along x, mirroring ``move``'s calling conventions:
+          - movex(dx)                 — translate by dx
+          - movex(destination=x)      — translate by x
+          - movex(origin=x0,
+                  destination=x1)     — translate by x1-x0
+        """
+        dx = float(origin) if destination is None else float(destination) - float(origin)
         ox, oy = self.origin
-        self.origin = (ox + float(dx), oy)
+        self.origin = (ox + dx, oy)
         return self
 
-    def movey(self, dy: float = 0.0) -> "ComponentReference":
+    def movey(
+        self,
+        origin: float = 0.0,
+        destination: Optional[float] = None,
+    ) -> "ComponentReference":
+        """Move along y. See :meth:`movex` for the calling conventions."""
+        dy = float(origin) if destination is None else float(destination) - float(origin)
         ox, oy = self.origin
-        self.origin = (ox, oy + float(dy))
+        self.origin = (ox, oy + dy)
         return self
 
     def move(
@@ -419,6 +440,16 @@ class ComponentReference:
         return ((x0 + x1) / 2.0, (y0 + y1) / 2.0)
 
     @property
+    def x(self) -> float:
+        """Centre x. gdsfactory exposes this on references, not just on cells."""
+        return self.center[0]
+
+    @property
+    def y(self) -> float:
+        """Centre y. Counterpart of :attr:`x`."""
+        return self.center[1]
+
+    @property
     def xmin(self) -> float: return self.bbox[0][0]
     @property
     def xmax(self) -> float: return self.bbox[1][0]
@@ -429,7 +460,15 @@ class ComponentReference:
 
     @property
     def name(self) -> str:
-        return self.parent.name
+        return self._name if self._name is not None else self.parent.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        # gdsfactory lets callers label a placement without touching the cell it
+        # points at (``ref.name = "pfet_2"``), and cells and tutorials do exactly
+        # that. Keep it on the reference: renaming the parent here would rename
+        # every other reference to the same cell too.
+        self._name = str(value)
 
     def __repr__(self) -> str:
         return f"ComponentReference(parent={self.parent.name!r}, origin={self.origin}, rotation={self.rotation})"
@@ -467,6 +506,21 @@ class Component:
     @name.setter
     def name(self, value: str) -> None:
         self._cell.name = str(value)
+
+    def show(self, *args, **kwargs) -> None:
+        """Open the layout in KLayout, like gdsfactory's Component.show().
+
+        Writes a temp .gds and hands it to klive when reachable. Tutorials
+        call this for interactive viewing, so it must stay quiet headless.
+        """
+        import tempfile
+        path = _os.path.join(tempfile.gettempdir(), f"{self.name}.gds")
+        self.write_gds(path)
+        try:
+            from gdsfactory.show import show as _gf_show  # type: ignore
+            _gf_show(path)
+        except Exception:
+            pass
 
     def __repr__(self) -> str:
         return f"Component(name={self.name!r}, ports={list(self.ports)}, refs={len(self._references)})"
@@ -773,7 +827,20 @@ class Component:
         visit(self._cell)
         return order
 
-    def write_gds(self, filename: str, unit: float = 1e-6, precision: float = 1e-9) -> str:
+    def write_gds(
+        self,
+        filename: Optional[str] = None,
+        unit: float = 1e-6,
+        precision: float = 1e-9,
+        gdsdir: Optional[str] = None,
+    ) -> str:
+        # Match gdsfactory's write_gds(gdspath=None, gdsdir=None): the path
+        # may be omitted (defaults to "<name>.gds") and a directory may be
+        # given on its own. Tutorials use both call styles.
+        if filename is None:
+            filename = f"{self.name}.gds"
+        if gdsdir is not None:
+            filename = str(_os.path.join(str(gdsdir), str(filename)))
         lib = gdstk.Library(unit=unit, precision=precision)
         used_names: set[str] = set()
         for cell in self._collect_cells():

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -267,6 +267,41 @@ def _as_layer(layer) -> Layer:
 # ---------------------------------------------------------------------------
 
 
+def _sort_ports_clockwise(ports: list) -> list:
+    """Order ports the way gdsfactory's select_ports() does.
+
+    select_ports defaults to clockwise=True, so ports come out bucketed by
+    orientation and swept west, north, east, south -- west sorted south to
+    north, north west to east, east north to south, south east to west.
+
+    The order is not cosmetic. Cells and notebooks pick ports out of
+    get_ports_list() by substring, e.g.
+
+        next(p for p in cap.get_ports_list() if "bottom_met" in p.name)
+
+    and a different order hands back a different port: on a 10x15 mimcap that
+    is array_row0_col0_bottom_met_W at (-4.250,-6.400) rather than
+    bottom_met_W at (-5.600,0.000), so the route lands somewhere else.
+    """
+    buckets = {"E": [], "N": [], "W": [], "S": []}
+    for p in ports:
+        angle = (p.orientation or 0) % 360
+        if angle <= 45 or angle >= 315:
+            buckets["E"].append(p)
+        elif 45 <= angle <= 135:
+            buckets["N"].append(p)
+        elif 135 <= angle <= 225:
+            buckets["W"].append(p)
+        else:
+            buckets["S"].append(p)
+
+    buckets["W"].sort(key=lambda p: +p.center[1])   # south to north
+    buckets["N"].sort(key=lambda p: +p.center[0])   # west to east
+    buckets["E"].sort(key=lambda p: -p.center[1])   # north to south
+    buckets["S"].sort(key=lambda p: -p.center[0])   # east to west
+    return buckets["W"] + buckets["N"] + buckets["E"] + buckets["S"]
+
+
 class ComponentReference:
     """Wraps a `gdstk.Reference`. Exposes transform mutation and transformed
     views of the parent component's ports/bbox."""
@@ -362,24 +397,37 @@ class ComponentReference:
         origin: Optional[Coord] = None,
         destination: Optional[Coord] = None,
     ) -> "ComponentReference":
-        """Move this reference. Two calling conventions:
-          - move((dx, dy))                    — translate by offset
-          - move(destination=(x, y))          — move so the ref's center lands at (x, y)
-          - move(origin=(x0, y0),
-                 destination=(x1, y1))        — translate by (x1-x0, y1-y0)
+        """Translate this reference by (destination - origin).
+
+        `origin` defaults to (0, 0), NOT to the reference's centre -- so
+        move(destination=(x, y)) is a plain translation by (x, y), the same as
+        move((x, y)). That is gdsfactory's signature, and the difference is not
+        academic: c_route places its extension rectangles with
+
+            e1_extension.move(destination=edge1.center)
+            e1_extension.movex(0 - evaluate_bbox(e1_extension)[0])
+
+        i.e. an absolute-looking call followed by relative nudges. Centring the
+        bbox on the destination instead injects an offset of half the
+        rectangle, and the route walks off: on the LIF neuron the met2 return
+        path ran to x=-8.125 instead of -1.250, widening the cell 8% and
+        raising 54 M2.2a violations that gdsfactory never produces.
+
+        Either endpoint may be a Port (or anything exposing `.center`), which
+        is how callers route to a port without unpacking it.
         """
-        if destination is None and origin is not None and not isinstance(origin, ComponentReference):
-            # single-arg form: treat as offset
-            return self.movex(origin[0]).movey(origin[1])
+        def _coord(v):
+            c = getattr(v, "center", None)
+            return (float(v[0]), float(v[1])) if c is None else (float(c[0]), float(c[1]))
+
         if destination is None:
-            return self
-        if origin is None:
-            # move by (destination - current center)
-            cx, cy = self.center
-            dx, dy = destination[0] - cx, destination[1] - cy
-        else:
-            dx, dy = destination[0] - origin[0], destination[1] - origin[1]
-        return self.movex(dx).movey(dy)
+            if origin is None:
+                return self
+            # single-arg form: move((dx, dy)) is a translation by that offset
+            destination, origin = origin, (0.0, 0.0)
+        ox, oy = _coord((0.0, 0.0) if origin is None else origin)
+        dx, dy = _coord(destination)
+        return self.movex(dx - ox).movey(dy - oy)
 
     def rotate(self, angle_deg: float, center: Coord = (0.0, 0.0)) -> "ComponentReference":
         # rotate the reference's placement about `center`
@@ -446,7 +494,7 @@ class ComponentReference:
                 if skip:
                     continue
             out.append(p)
-        return out
+        return _sort_ports_clockwise(out)
 
     @property
     def bbox(self) -> tuple[Coord, Coord]:
@@ -676,7 +724,7 @@ class Component:
                 out.append(p.copy(name=f"{prefix}{name}"))
             else:
                 out.append(p)
-        return out
+        return _sort_ports_clockwise(out)
 
     # --- geometry ---------------------------------------------------------
     def add_polygon(self, points, layer: Optional[Layer] = None) -> gdstk.Polygon:

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -616,8 +616,34 @@ class Component:
         return self
 
     # --- add / << ----------------------------------------------------------
-    def add_ref(self, component: "Component", alias: Optional[str] = None) -> ComponentReference:
-        ref = component.ref()
+    def add_ref(
+        self,
+        component: "Component",
+        alias: Optional[str] = None,
+        columns: int = 1,
+        rows: int = 1,
+        spacing: Optional[tuple] = None,
+    ) -> ComponentReference:
+        """Reference `component`, optionally as a repeated array.
+
+        gdsfactory accepts columns/rows/spacing here and the BJT tutorial
+        lays its contact rings out that way. gdstk has the same notion
+        natively, so the array stays one reference rather than becoming
+        rows*columns of them.
+        """
+        if columns != 1 or rows != 1:
+            if spacing is None:
+                raise ValueError(
+                    "add_ref: spacing is required when columns or rows > 1"
+                )
+            gref = gdstk.Reference(
+                component._cell, origin=(0.0, 0.0),
+                columns=int(columns), rows=int(rows),
+                spacing=(float(spacing[0]), float(spacing[1])),
+            )
+            ref = ComponentReference(component, gref)
+        else:
+            ref = component.ref()
         self.add(ref)
         return ref
 

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -477,6 +477,21 @@ class ComponentReference:
             for name, p in self.parent.ports.items()
         }
 
+    def __getitem__(self, key: str) -> Port:
+        """comp["port_name"], como en gdsfactory.
+
+        No es azucar: primitivos como bjt indexan el componente para leer el
+        ancho de un puerto, y sin esto el error que sale ("Component object is
+        not subscriptable") no dice nada del puerto que buscaba.
+        """
+        try:
+            return self.ports[key]
+        except KeyError:
+            raise KeyError(
+                f"no port {key!r} on {getattr(self, 'name', self)!r}; "
+                f"hay {sorted(self.ports)[:8]}..."
+            ) from None
+
     def get_ports_list(self, prefix: str = "", **filters) -> list[Port]:
         """Filter ports. `prefix` filters to names starting with that prefix
         (matches gdsfactory.component.Component.get_ports_list). Extra
@@ -684,9 +699,14 @@ class Component:
 
     def add_ports(
         self,
-        ports: Iterable[Port],
+        ports: Union[Iterable[Port], "dict[str, Port]"],
         prefix: str = "",
     ) -> "Component":
+        # gdsfactory accepts either a sequence of ports or a name->port mapping,
+        # and glayout passes `ref.ports` -- a dict -- straight through. Iterating
+        # that yields the names, so `p.name` blows up with a str.
+        if hasattr(ports, "values"):
+            ports = list(ports.values())
         for p in ports:
             new_name = f"{prefix}{p.name}" if prefix else p.name
             np = p.copy(name=new_name)
@@ -708,6 +728,21 @@ class Component:
             print("%-42s (%9.3f, %9.3f)  ancho %7.3f  %5.1f  %s"
                   % (name, p.center[0], p.center[1], p.width,
                      p.orientation or 0.0, p.layer))
+
+    def __getitem__(self, key: str) -> Port:
+        """comp["port_name"], como en gdsfactory.
+
+        No es azucar: primitivos como bjt indexan el componente para leer el
+        ancho de un puerto, y sin esto el error que sale ("Component object is
+        not subscriptable") no dice nada del puerto que buscaba.
+        """
+        try:
+            return self.ports[key]
+        except KeyError:
+            raise KeyError(
+                f"no port {key!r} on {getattr(self, 'name', self)!r}; "
+                f"hay {sorted(self.ports)[:8]}..."
+            ) from None
 
     def get_ports_list(self, prefix: str = "", **filters) -> list[Port]:
         out: list[Port] = []

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -267,6 +267,41 @@ def _as_layer(layer) -> Layer:
 # ---------------------------------------------------------------------------
 
 
+def _sort_ports_clockwise(ports: list) -> list:
+    """Order ports the way gdsfactory's select_ports() does.
+
+    select_ports defaults to clockwise=True, so ports come out bucketed by
+    orientation and swept west, north, east, south -- west sorted south to
+    north, north west to east, east north to south, south east to west.
+
+    The order is not cosmetic. Cells and notebooks pick ports out of
+    get_ports_list() by substring, e.g.
+
+        next(p for p in cap.get_ports_list() if "bottom_met" in p.name)
+
+    and a different order hands back a different port: on a 10x15 mimcap that
+    is array_row0_col0_bottom_met_W at (-4.250,-6.400) rather than
+    bottom_met_W at (-5.600,0.000), so the route lands somewhere else.
+    """
+    buckets = {"E": [], "N": [], "W": [], "S": []}
+    for p in ports:
+        angle = (p.orientation or 0) % 360
+        if angle <= 45 or angle >= 315:
+            buckets["E"].append(p)
+        elif 45 <= angle <= 135:
+            buckets["N"].append(p)
+        elif 135 <= angle <= 225:
+            buckets["W"].append(p)
+        else:
+            buckets["S"].append(p)
+
+    buckets["W"].sort(key=lambda p: +p.center[1])   # south to north
+    buckets["N"].sort(key=lambda p: +p.center[0])   # west to east
+    buckets["E"].sort(key=lambda p: -p.center[1])   # north to south
+    buckets["S"].sort(key=lambda p: -p.center[0])   # east to west
+    return buckets["W"] + buckets["N"] + buckets["E"] + buckets["S"]
+
+
 class ComponentReference:
     """Wraps a `gdstk.Reference`. Exposes transform mutation and transformed
     views of the parent component's ports/bbox."""
@@ -347,24 +382,37 @@ class ComponentReference:
         origin: Optional[Coord] = None,
         destination: Optional[Coord] = None,
     ) -> "ComponentReference":
-        """Move this reference. Two calling conventions:
-          - move((dx, dy))                    — translate by offset
-          - move(destination=(x, y))          — move so the ref's center lands at (x, y)
-          - move(origin=(x0, y0),
-                 destination=(x1, y1))        — translate by (x1-x0, y1-y0)
+        """Translate this reference by (destination - origin).
+
+        `origin` defaults to (0, 0), NOT to the reference's centre -- so
+        move(destination=(x, y)) is a plain translation by (x, y), the same as
+        move((x, y)). That is gdsfactory's signature, and the difference is not
+        academic: c_route places its extension rectangles with
+
+            e1_extension.move(destination=edge1.center)
+            e1_extension.movex(0 - evaluate_bbox(e1_extension)[0])
+
+        i.e. an absolute-looking call followed by relative nudges. Centring the
+        bbox on the destination instead injects an offset of half the
+        rectangle, and the route walks off: on the LIF neuron the met2 return
+        path ran to x=-8.125 instead of -1.250, widening the cell 8% and
+        raising 54 M2.2a violations that gdsfactory never produces.
+
+        Either endpoint may be a Port (or anything exposing `.center`), which
+        is how callers route to a port without unpacking it.
         """
-        if destination is None and origin is not None and not isinstance(origin, ComponentReference):
-            # single-arg form: treat as offset
-            return self.movex(origin[0]).movey(origin[1])
+        def _coord(v):
+            c = getattr(v, "center", None)
+            return (float(v[0]), float(v[1])) if c is None else (float(c[0]), float(c[1]))
+
         if destination is None:
-            return self
-        if origin is None:
-            # move by (destination - current center)
-            cx, cy = self.center
-            dx, dy = destination[0] - cx, destination[1] - cy
-        else:
-            dx, dy = destination[0] - origin[0], destination[1] - origin[1]
-        return self.movex(dx).movey(dy)
+            if origin is None:
+                return self
+            # single-arg form: move((dx, dy)) is a translation by that offset
+            destination, origin = origin, (0.0, 0.0)
+        ox, oy = _coord((0.0, 0.0) if origin is None else origin)
+        dx, dy = _coord(destination)
+        return self.movex(dx - ox).movey(dy - oy)
 
     def rotate(self, angle_deg: float, center: Coord = (0.0, 0.0)) -> "ComponentReference":
         # rotate the reference's placement about `center`
@@ -431,7 +479,7 @@ class ComponentReference:
                 if skip:
                     continue
             out.append(p)
-        return out
+        return _sort_ports_clockwise(out)
 
     @property
     def bbox(self) -> tuple[Coord, Coord]:
@@ -628,7 +676,7 @@ class Component:
                 out.append(p.copy(name=f"{prefix}{name}"))
             else:
                 out.append(p)
-        return out
+        return _sort_ports_clockwise(out)
 
     # --- geometry ---------------------------------------------------------
     def add_polygon(self, points, layer: Optional[Layer] = None) -> gdstk.Polygon:

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -29,6 +29,7 @@ PathType = Union[str, _Path]
 # cell_decorator_settings, .activate()). Extra fields are allowed so callers
 # can pass arbitrary pdk-specific config.
 from pydantic import BaseModel, ConfigDict  # noqa: E402
+import os as _os
 
 
 class _GdsWriteSettings(BaseModel):
@@ -264,6 +265,8 @@ class ComponentReference:
         self._ref = gref
         # owner is the Component this reference has been added to (not the target)
         self.owner: Optional["Component"] = None
+        # a label for this placement; falls back to the target cell's name
+        self._name: Optional[str] = None
         # `info` is used by some cells to attach netlist / hierarchy metadata.
         self.info: dict = {}
 
@@ -294,14 +297,31 @@ class ComponentReference:
         self._ref.x_reflection = bool(value)
 
     # --- movement (mutate + return self) ----------------------------------
-    def movex(self, dx: float = 0.0) -> "ComponentReference":
+    def movex(
+        self,
+        origin: float = 0.0,
+        destination: Optional[float] = None,
+    ) -> "ComponentReference":
+        """Move along x, mirroring ``move``'s calling conventions:
+          - movex(dx)                 — translate by dx
+          - movex(destination=x)      — translate by x
+          - movex(origin=x0,
+                  destination=x1)     — translate by x1-x0
+        """
+        dx = float(origin) if destination is None else float(destination) - float(origin)
         ox, oy = self.origin
-        self.origin = (ox + float(dx), oy)
+        self.origin = (ox + dx, oy)
         return self
 
-    def movey(self, dy: float = 0.0) -> "ComponentReference":
+    def movey(
+        self,
+        origin: float = 0.0,
+        destination: Optional[float] = None,
+    ) -> "ComponentReference":
+        """Move along y. See :meth:`movex` for the calling conventions."""
+        dy = float(origin) if destination is None else float(destination) - float(origin)
         ox, oy = self.origin
-        self.origin = (ox, oy + float(dy))
+        self.origin = (ox, oy + dy)
         return self
 
     def move(
@@ -405,6 +425,16 @@ class ComponentReference:
         return ((x0 + x1) / 2.0, (y0 + y1) / 2.0)
 
     @property
+    def x(self) -> float:
+        """Centre x. gdsfactory exposes this on references, not just on cells."""
+        return self.center[0]
+
+    @property
+    def y(self) -> float:
+        """Centre y. Counterpart of :attr:`x`."""
+        return self.center[1]
+
+    @property
     def xmin(self) -> float: return self.bbox[0][0]
     @property
     def xmax(self) -> float: return self.bbox[1][0]
@@ -415,7 +445,15 @@ class ComponentReference:
 
     @property
     def name(self) -> str:
-        return self.parent.name
+        return self._name if self._name is not None else self.parent.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        # gdsfactory lets callers label a placement without touching the cell it
+        # points at (``ref.name = "pfet_2"``), and cells and tutorials do exactly
+        # that. Keep it on the reference: renaming the parent here would rename
+        # every other reference to the same cell too.
+        self._name = str(value)
 
     def __repr__(self) -> str:
         return f"ComponentReference(parent={self.parent.name!r}, origin={self.origin}, rotation={self.rotation})"
@@ -453,6 +491,21 @@ class Component:
     @name.setter
     def name(self, value: str) -> None:
         self._cell.name = str(value)
+
+    def show(self, *args, **kwargs) -> None:
+        """Open the layout in KLayout, like gdsfactory's Component.show().
+
+        Writes a temp .gds and hands it to klive when reachable. Tutorials
+        call this for interactive viewing, so it must stay quiet headless.
+        """
+        import tempfile
+        path = _os.path.join(tempfile.gettempdir(), f"{self.name}.gds")
+        self.write_gds(path)
+        try:
+            from gdsfactory.show import show as _gf_show  # type: ignore
+            _gf_show(path)
+        except Exception:
+            pass
 
     def __repr__(self) -> str:
         return f"Component(name={self.name!r}, ports={list(self.ports)}, refs={len(self._references)})"
@@ -726,7 +779,20 @@ class Component:
         visit(self._cell)
         return order
 
-    def write_gds(self, filename: str, unit: float = 1e-6, precision: float = 1e-9) -> str:
+    def write_gds(
+        self,
+        filename: Optional[str] = None,
+        unit: float = 1e-6,
+        precision: float = 1e-9,
+        gdsdir: Optional[str] = None,
+    ) -> str:
+        # Match gdsfactory's write_gds(gdspath=None, gdsdir=None): the path
+        # may be omitted (defaults to "<name>.gds") and a directory may be
+        # given on its own. Tutorials use both call styles.
+        if filename is None:
+            filename = f"{self.name}.gds"
+        if gdsdir is not None:
+            filename = str(_os.path.join(str(gdsdir), str(filename)))
         lib = gdstk.Library(unit=unit, precision=precision)
         used_names: set[str] = set()
         for cell in self._collect_cells():

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -601,8 +601,34 @@ class Component:
         return self
 
     # --- add / << ----------------------------------------------------------
-    def add_ref(self, component: "Component", alias: Optional[str] = None) -> ComponentReference:
-        ref = component.ref()
+    def add_ref(
+        self,
+        component: "Component",
+        alias: Optional[str] = None,
+        columns: int = 1,
+        rows: int = 1,
+        spacing: Optional[tuple] = None,
+    ) -> ComponentReference:
+        """Reference `component`, optionally as a repeated array.
+
+        gdsfactory accepts columns/rows/spacing here and the BJT tutorial
+        lays its contact rings out that way. gdstk has the same notion
+        natively, so the array stays one reference rather than becoming
+        rows*columns of them.
+        """
+        if columns != 1 or rows != 1:
+            if spacing is None:
+                raise ValueError(
+                    "add_ref: spacing is required when columns or rows > 1"
+                )
+            gref = gdstk.Reference(
+                component._cell, origin=(0.0, 0.0),
+                columns=int(columns), rows=int(rows),
+                spacing=(float(spacing[0]), float(spacing[1])),
+            )
+            ref = ComponentReference(component, gref)
+        else:
+            ref = component.ref()
         self.add(ref)
         return ref
 

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -462,6 +462,21 @@ class ComponentReference:
             for name, p in self.parent.ports.items()
         }
 
+    def __getitem__(self, key: str) -> Port:
+        """comp["port_name"], como en gdsfactory.
+
+        No es azucar: primitivos como bjt indexan el componente para leer el
+        ancho de un puerto, y sin esto el error que sale ("Component object is
+        not subscriptable") no dice nada del puerto que buscaba.
+        """
+        try:
+            return self.ports[key]
+        except KeyError:
+            raise KeyError(
+                f"no port {key!r} on {getattr(self, 'name', self)!r}; "
+                f"hay {sorted(self.ports)[:8]}..."
+            ) from None
+
     def get_ports_list(self, prefix: str = "", **filters) -> list[Port]:
         """Filter ports. `prefix` filters to names starting with that prefix
         (matches gdsfactory.component.Component.get_ports_list). Extra
@@ -649,9 +664,14 @@ class Component:
 
     def add_ports(
         self,
-        ports: Iterable[Port],
+        ports: Union[Iterable[Port], "dict[str, Port]"],
         prefix: str = "",
     ) -> "Component":
+        # gdsfactory accepts either a sequence of ports or a name->port mapping,
+        # and glayout passes `ref.ports` -- a dict -- straight through. Iterating
+        # that yields the names, so `p.name` blows up with a str.
+        if hasattr(ports, "values"):
+            ports = list(ports.values())
         for p in ports:
             new_name = f"{prefix}{p.name}" if prefix else p.name
             np = p.copy(name=new_name)
@@ -660,6 +680,21 @@ class Component:
                 raise ValueError(f"duplicate port name {new_name!r} on component {self.name!r}")
             self.ports[new_name] = np
         return self
+
+    def __getitem__(self, key: str) -> Port:
+        """comp["port_name"], como en gdsfactory.
+
+        No es azucar: primitivos como bjt indexan el componente para leer el
+        ancho de un puerto, y sin esto el error que sale ("Component object is
+        not subscriptable") no dice nada del puerto que buscaba.
+        """
+        try:
+            return self.ports[key]
+        except KeyError:
+            raise KeyError(
+                f"no port {key!r} on {getattr(self, 'name', self)!r}; "
+                f"hay {sorted(self.ports)[:8]}..."
+            ) from None
 
     def get_ports_list(self, prefix: str = "", **filters) -> list[Port]:
         out: list[Port] = []

--- a/src/glayout/backend/_gdstk.py
+++ b/src/glayout/backend/_gdstk.py
@@ -44,6 +44,10 @@ class _CellDecoratorSettings(BaseModel):
     cache: bool = False
 
 
+# The PDK whose grid snap_to_grid() should use. Set by Pdk.activate().
+_ACTIVE_PDK: Optional["Pdk"] = None
+
+
 class Pdk(BaseModel):
     """Minimal shim for gdsfactory.pdk.Pdk. Holds enough state for
     MappedPDK to function."""
@@ -53,15 +57,29 @@ class Pdk(BaseModel):
     name: str
     layers: Optional[dict] = None
     default_decorator: Optional[Any] = None
-    grid_size: float = 0.001  # microns; matches gdsfactory default
+    grid_size: float = 0.001  # microns; corrected in activate() from precision
     gds_write_settings: _GdsWriteSettings = _GdsWriteSettings()
     cell_decorator_settings: _CellDecoratorSettings = _CellDecoratorSettings()
 
     def activate(self) -> None:
-        """No-op. gdsfactory's activate() registered the PDK in a global
-        registry; that registry is a gdsfactory concern and isn't needed
-        once gdsfactory is out of the import graph."""
-        return None
+        """Register this PDK as the active one.
+
+        gdsfactory kept a global registry so that helpers like snap_to_grid
+        could look up the process grid. Most of that registry is a gdsfactory
+        concern, but the grid is not: snapping to the wrong pitch puts every
+        vertex off-grid, and the DRC reports it on all of them.
+        """
+        # gdsfactory filled grid_size in from its PDK database here. Without
+        # that database the class default (1 nm) survives, and snapping a 5 nm
+        # process to 1 nm puts every vertex off-grid -- the DRC then flags
+        # comp, metal, contact and via alike. precision already carries the
+        # real pitch, so derive it rather than duplicating the number.
+        precision_um = float(self.gds_write_settings.precision) * 1e6
+        if precision_um > 0 and self.grid_size != precision_um:
+            object.__setattr__(self, "grid_size", precision_um)
+
+        global _ACTIVE_PDK
+        _ACTIVE_PDK = self
 
     def validate_layers(self, layers_required) -> None:
         """Mimics gdsfactory.pdk.Pdk.validate_layers — raise if any named
@@ -836,16 +854,23 @@ def Polygon(points, layer=(0, 0), datatype=None) -> gdstk.Polygon:
 # ---------------------------------------------------------------------------
 
 
-def snap_to_grid(x, nm: int = 1):
-    """Snap `x` (in micrometers) to an `nm`-nanometer grid.
+def snap_to_grid(x, nm: Optional[int] = None, grid_factor: int = 1):
+    """Snap `x` (in micrometers) to the active PDK's grid.
 
-    Matches gdsfactory.snap.snap_to_grid semantics used in this repo.
+    Mirrors gdsfactory.snap.snap_to_grid, which reads the grid from the active
+    PDK rather than assuming one: gf180 is on 5 nm, and snapping it to 1 nm
+    leaves every vertex off-grid (the DRC then flags comp, metal, contact and
+    via alike). `nm` overrides the lookup when a caller needs a specific pitch.
+
     Accepts scalars or iterables.
     """
     if x is None:
         return None
     if isinstance(x, (list, tuple)):
-        return type(x)(snap_to_grid(v, nm) for v in x)
+        return type(x)(snap_to_grid(v, nm, grid_factor) for v in x)
+    if nm is None:
+        grid_um = _ACTIVE_PDK.grid_size if _ACTIVE_PDK is not None else 0.001
+        nm = max(1, int(round(grid_um * 1000.0 * grid_factor)))
     return round(float(x) * 1000.0 / nm) * nm / 1000.0
 
 

--- a/tests/notebooks/run_tutorial_notebooks.py
+++ b/tests/notebooks/run_tutorial_notebooks.py
@@ -119,6 +119,41 @@ def _scan_executed(path: Path) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _strip_displays(nb: Path) -> Path:
+    """Write a sibling copy of `nb` with display calls removed, for CI.
+
+    The tutorials push multi-MB SVGs through iopub (display_component draws
+    the whole opamp: ~2.7 MB per message). Measured on the runner itself,
+    that is what stalls the kernel<->client transport: the same notebook run
+    3x with displays stalled or died every time, and 3x without them ran
+    clean in 12.5s. CI executes for regressions, not for pictures, so the
+    displays go.
+
+    Lines are dropped, not commented, matching the measured experiment. If
+    dropping a line leaves a cell that no longer compiles (say, a display
+    that was the only statement under a `with`), that cell keeps its
+    original source: correctness over stripping.
+    """
+    import json
+    doc = json.loads(nb.read_text(encoding="utf-8"))
+    quitar = ("display_component(", "display_gds(", "display(")
+    for cell in doc.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        original = cell["source"]
+        kept = [l for l in original if not any(q in l for q in quitar)]
+        if kept == original:
+            continue
+        try:
+            compile("".join(kept), "<cell>", "exec")
+        except SyntaxError:
+            continue
+        cell["source"] = kept
+    out = nb.with_name(nb.stem + "__stripped.ipynb")
+    out.write_text(json.dumps(doc), encoding="utf-8")
+    return out
+
+
 def _run_one(
     nb: Path,
     executed_dir: Path,
@@ -126,10 +161,12 @@ def _run_one(
     timeout_per_cell: int,
     timeout_per_notebook: int,
     kernel_name: str,
+    strip_displays: bool = False,
 ) -> NotebookResult:
     rel = str(nb.relative_to(REPO_ROOT))
     stem = nb.stem
     workdir = nb.parent
+    a_ejecutar = _strip_displays(nb) if strip_displays else nb
     executed = executed_dir / f"{stem}.ipynb"
     log = log_dir / f"{stem}.log"
     executed.parent.mkdir(parents=True, exist_ok=True)
@@ -141,7 +178,7 @@ def _run_one(
         "--ExecutePreprocessor.allow_errors=True",
         f"--ExecutePreprocessor.kernel_name={kernel_name}",
         "--output", str(executed),
-        nb.name,
+        a_ejecutar.name,
     ]
     print(f"[RUN]  {rel}", flush=True)
     start = time.monotonic()
@@ -260,6 +297,18 @@ def main() -> int:
         help="Jupyter kernel name to launch (default: python3).",
     )
     p.add_argument(
+        "--strip-displays", action="store_true",
+        help="Drop display calls before executing. The multi-MB SVGs they "
+             "push through iopub are what stalls the kernel transport in CI "
+             "(measured: 3/3 stalled with them, 3/3 clean at 12.5s without).",
+    )
+    p.add_argument(
+        "--retries", type=int, default=0,
+        help="Re-run a notebook that ends in 'error' (crash/timeout, not a "
+             "cell failure) up to this many times. Transport races lose "
+             "messages; a genuinely broken notebook still fails every try.",
+    )
+    p.add_argument(
         "--only", default=None,
         help="Comma-separated notebook basenames (with or without .ipynb) to limit the run.",
     )
@@ -288,12 +337,24 @@ def main() -> int:
 
     results: List[NotebookResult] = []
     for nb in nbs:
-        r = _run_one(
-            nb, executed_dir, log_dir,
-            timeout_per_cell=args.cell_timeout,
-            timeout_per_notebook=args.notebook_timeout,
-            kernel_name=args.kernel_name,
-        )
+        for intento in range(1 + max(0, args.retries)):
+            r = _run_one(
+                nb, executed_dir, log_dir,
+                timeout_per_cell=args.cell_timeout,
+                timeout_per_notebook=args.notebook_timeout,
+                kernel_name=args.kernel_name,
+                strip_displays=args.strip_displays,
+            )
+            # only "error" (nbconvert crash / timeout) is worth retrying:
+            # that is the transport-race class. A "fail" is a real cell
+            # exception and retrying it would only hide it.
+            if r.status != "error" or intento == args.retries:
+                break
+            print(f"[RETRY] {r.notebook} ({r.duration_s:.1f}s) "
+                  f"{r.error_name}: attempt {intento + 2}", flush=True)
+        temporal = nb.with_name(nb.stem + "__stripped.ipynb")
+        if temporal.exists():
+            temporal.unlink()
         print(f"[{r.status.upper()}] {r.notebook} ({r.duration_s:.1f}s)" +
               (f" — cell {r.errored_cell} {r.error_name}: {r.error_message}"
                if r.status != "pass" else ""),

--- a/tests/test_gdstk_backend.py
+++ b/tests/test_gdstk_backend.py
@@ -30,6 +30,28 @@ class GdstkBackendTests(unittest.TestCase):
         c.add_port(name="p1", center=(0, 0), width=1, orientation=0, layer=(1, 0))
         self.assertIn("p1", c.ports)
 
+    def test_add_ref_array(self):
+        """add_ref(columns=, rows=, spacing=) lays out a repeated reference.
+
+        `test_bjt_gdsfactory` builds its contact rings this way. Without it
+        the notebook dies on a TypeError halfway through.
+        """
+        from glayout.backend import Component, rectangle
+        c = Component("array_probe")
+        unit = rectangle(size=(1, 1), layer=(1, 0))
+        ref = c.add_ref(unit, columns=3, rows=2, spacing=(2, 2))
+        self.assertIsNotNone(ref)
+        # 3 columns at pitch 2 span 1 + 2*2 = 5; 2 rows span 1 + 2 = 3.
+        (x0, y0), (x1, y1) = c.bbox
+        self.assertAlmostEqual(x1 - x0, 5.0)
+        self.assertAlmostEqual(y1 - y0, 3.0)
+
+    def test_add_ref_array_needs_spacing(self):
+        from glayout.backend import Component, rectangle
+        c = Component("array_probe_nospacing")
+        with self.assertRaises(ValueError):
+            c.add_ref(rectangle(size=(1, 1), layer=(1, 0)), columns=2)
+
     def test_primitives_build(self):
         from glayout.pdk.sky130_mapped.sky130_mapped import sky130_mapped_pdk as pdk
         from glayout.primitives.via_gen import via_stack, via_array

--- a/tests/test_gdstk_backend.py
+++ b/tests/test_gdstk_backend.py
@@ -88,5 +88,81 @@ class GdstkBackendTests(unittest.TestCase):
             self.assertGreater(os.path.getsize(path), 0)
 
 
+class GridSnapTests(unittest.TestCase):
+    """The grid the backend rounds to has to come from the PDK.
+
+    gf180 and sky130 are both 5 nm processes. `snap_to_grid` used to take a
+    bare `nm: int = 1`, so a coordinate the process wants at 10.245 was kept
+    at 10.246 -- legal at 1 nm, off-grid at 5 nm, and the DRC flags every
+    such vertex: comp, metal, contact and via alike. These tests pin the
+    grid to the PDK so a 1 nm default cannot come back unnoticed.
+    """
+
+    GRID_UM = 0.005  # gf180 / sky130 manufacturing grid
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ["GLAYOUT_BACKEND"] = "gdstk"
+        os.environ.setdefault("PDK_ROOT", "/tmp")
+        from glayout import backend
+        backend.set_backend("gdstk")
+
+    def _gf180(self):
+        from glayout.pdk.gf180_mapped.gf180_mapped import gf180_mapped_pdk
+        gf180_mapped_pdk.activate()
+        return gf180_mapped_pdk
+
+    def test_activate_derives_grid_from_precision(self):
+        """activate() must take the grid from precision, not keep the default.
+
+        precision already carries the real pitch (5e-9 m), so the grid is
+        derived from it rather than written down a second place that could
+        drift out of step with it.
+        """
+        pdk = self._gf180()
+        self.assertAlmostEqual(pdk.grid_size, self.GRID_UM, places=9)
+
+    def test_snap_lands_on_the_pdk_grid(self):
+        """The value in the bug report: 10.246 is legal at 1 nm, not at 5 nm."""
+        from glayout.backend import snap_to_grid
+        self._gf180()
+        self.assertAlmostEqual(snap_to_grid(10.2463), 10.245, places=9)
+        self.assertAlmostEqual(snap_to_grid(-0.0011), 0.0, places=9)
+        for value in (0.0012, 3.14159, 10.2463, -7.7777):
+            snapped = snap_to_grid(value)
+            self.assertAlmostEqual(
+                snapped / self.GRID_UM, round(snapped / self.GRID_UM), places=6,
+                msg=f"{value} snapped to {snapped}, which is off a 5 nm grid",
+            )
+
+    def test_explicit_pitch_still_overrides(self):
+        """Callers that need a specific pitch keep the old behaviour."""
+        from glayout.backend import snap_to_grid
+        self._gf180()
+        self.assertAlmostEqual(snap_to_grid(10.2463, nm=1), 10.246, places=9)
+
+    def test_built_geometry_lands_on_the_grid(self):
+        """The end-to-end claim: real devices come out on-grid.
+
+        Snapping scalars correctly is not the same as a built cell being
+        clean -- the generators compose dozens of snapped values. This walks
+        every vertex of a flattened device and is the check that corresponds
+        to what the DRC reports.
+        """
+        pdk = self._gf180()
+        from glayout.primitives.fet import nmos
+        device = nmos(pdk, fingers=2)
+        fuera = []
+        for polygon in device._cell.get_polygons(depth=None):
+            for x, y in polygon.points:
+                for coord in (x, y):
+                    pasos = coord / self.GRID_UM
+                    if abs(pasos - round(pasos)) > 1e-6:
+                        fuera.append(coord)
+        self.assertEqual(
+            fuera[:8], [], f"{len(fuera)} vertices off the 5 nm grid",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tutorial/BJT_tutorials/test_bjt_gdsfactory.ipynb
+++ b/tutorial/BJT_tutorials/test_bjt_gdsfactory.ipynb
@@ -47,9 +47,10 @@
    "source": [
     "from glayout import MappedPDK, sky130 , gf180\n",
     "#from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.geometry import boolean\n",
-    "from gdsfactory.components import text_freetype, rectangle, array, rectangular_ring"
+    "from glayout.backend import Component\n",
+    "from glayout.backend import boolean\n",
+    "from glayout.backend import rectangle, rectangular_ring\n",
+    "from gdsfactory.components import text_freetype, array"
    ]
   },
   {

--- a/tutorial/GLayout_Cmirror.ipynb
+++ b/tutorial/GLayout_Cmirror.ipynb
@@ -37,7 +37,7 @@
     "from glayout.util.comp_utils import move, movex, movey, align_comp_to_port, evaluate_bbox, prec_center\n",
     "from glayout.routing.straight_route import straight_route\n",
     "from glayout.routing.c_route import c_route\n",
-    "from gdsfactory import Component\n",
+    "from glayout.backend import Component\n",
     "import gdstk\n",
     "import svgutils.transform as sg\n",
     "import IPython.display\n",
@@ -103,7 +103,7 @@
     "from glayout.util.comp_utils import evaluate_bbox, prec_center\n",
     "from glayout.routing.straight_route import straight_route\n",
     "from glayout.routing.c_route import c_route\n",
-    "from gdsfactory import Component\n"
+    "from glayout.backend import Component\n"
    ]
   },
   {

--- a/tutorial/GLayout_Introduction.ipynb
+++ b/tutorial/GLayout_Introduction.ipynb
@@ -193,8 +193,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import rectangle\n",
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
     "\n",
     "def makeMet1Rectangle(pdk, length):\n",
     "  met1 = pdk.get_glayer(\"met1\")\n",

--- a/tutorial/GLayout_Via.ipynb
+++ b/tutorial/GLayout_Via.ipynb
@@ -104,8 +104,8 @@
    "outputs": [],
    "source": [
     "from glayout import sky130, gf180\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import rectangle"
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle"
    ]
   },
   {

--- a/tutorial/glayout_tutorial_5T_OTA_part1.ipynb
+++ b/tutorial/glayout_tutorial_5T_OTA_part1.ipynb
@@ -136,8 +136,9 @@
    "outputs": [],
    "source": [
     "from glayout import MappedPDK, sky130, gf180\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle\n",
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype\n",
     "\n",
     "from glayout import nmos, pmos\n",
     "from glayout import via_stack\n",

--- a/tutorial/glayout_tutorial_5T_OTA_part2.ipynb
+++ b/tutorial/glayout_tutorial_5T_OTA_part2.ipynb
@@ -95,8 +95,9 @@
    "source": [
     "from glayout import MappedPDK, sky130 , gf180\n",
     "#from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle"
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype"
    ]
   },
   {
@@ -236,8 +237,9 @@
     "fivet_ota_code_string = \"\"\"\n",
     "from glayout import MappedPDK, sky130 , gf180\n",
     "# from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle\n",
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype\n",
     "\n",
     "from glayout import nmos, pmos\n",
     "from glayout import via_stack\n",

--- a/tutorial/glayout_tutorial_FVF_part1.ipynb
+++ b/tutorial/glayout_tutorial_FVF_part1.ipynb
@@ -171,8 +171,9 @@
    "source": [
     "from glayout import MappedPDK, sky130 , gf180\n",
     "#from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle"
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype"
    ]
   },
   {
@@ -863,8 +864,9 @@
     "fvf_code_string = \"\"\"\n",
     "from glayout import MappedPDK, sky130 , gf180\n",
     "# from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle\n",
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype\n",
     "\n",
     "from glayout import nmos, pmos\n",
     "from glayout import via_stack\n",

--- a/tutorial/glayout_tutorial_FVF_part2.ipynb
+++ b/tutorial/glayout_tutorial_FVF_part2.ipynb
@@ -113,8 +113,9 @@
    "source": [
     "from glayout import MappedPDK, sky130 , gf180\n",
     "#from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle"
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype"
    ]
   },
   {

--- a/tutorial/glayout_tutorial_INV_part1.ipynb
+++ b/tutorial/glayout_tutorial_INV_part1.ipynb
@@ -164,8 +164,9 @@
    "source": [
     "from glayout import MappedPDK, sky130 , gf180\n",
     "#from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle"
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype"
    ]
   },
   {
@@ -803,9 +804,10 @@
    "source": [
     "inv_code_string = \"\"\"\n",
     "from glayout import MappedPDK, sky130 , gf180\n",
-    "from gdsfactory.cell import cell\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle\n",
+    "from glayout.backend import cell\n",
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype\n",
     "\n",
     "from glayout import nmos, pmos\n",
     "from glayout import via_stack\n",

--- a/tutorial/glayout_tutorial_INV_part2.ipynb
+++ b/tutorial/glayout_tutorial_INV_part2.ipynb
@@ -105,8 +105,9 @@
    "outputs": [],
    "source": [
     "from glayout import MappedPDK, sky130 , gf180\n",
-    "from gdsfactory import Component\n",
-    "from gdsfactory.components import text_freetype, rectangle\n",
+    "from glayout.backend import Component\n",
+    "from glayout.backend import rectangle\n",
+    "from gdsfactory.components import text_freetype\n",
     "\n",
     "import gdsfactory as gf\n",
     "gf.clear_cache()"


### PR DESCRIPTION
Running the tutorial notebooks under `GLAYOUT_BACKEND=gdstk` fails almost
immediately — 4 of 14 pass. Two causes, one on each side.

### The notebooks bypass the backend selection

```python
from gdsfactory import Component        # 10 notebooks
```

Under the default backend this resolves to the same class as
`glayout.backend.Component`, so nobody notices. Under gdstk, gdsfactory's
`add_ref()` receives a gdstk `Component` and rejects it:

```
TypeError: type = <class 'type'> needs to be a Component.
```

Redirected `Component`, `rectangle`, `rectangular_ring`, `boolean` and
`cell` to `glayout.backend`. Symbols it does not re-export
(`text_freetype`, `array`) stay on gdsfactory. Imports only — no cell
content touched.

### The gdstk backend is missing parts of the surface

Each of these is used by glayout's own cells or by the tutorials:

| | before | after |
|---|---|---|
| `movex` / `movey` | bare delta | `destination=` too, like `move()` already had |
| `ref.name` | read-only | assignable (`ref.name = "pfet_2"`) |
| `ref.x` / `ref.y` | absent | centre accessors, next to the existing `xmin`/`xmax` |
| `write_gds` | `filename` required, no `gdsdir` | both optional, as in gdsfactory |
| `Component.show` | absent | writes a temp GDS, hands it to klive if reachable |

`ref.name` stores the label on the reference rather than renaming the
target cell — renaming the cell would rename every other placement of it.

### Result

```
tutorial notebooks, GLAYOUT_BACKEND=gdstk:   4/14  ->  10/14
```

The three BJT tutorials still fail on `Component` indexing and
`add_ref(columns=)`; those need more than a signature and are left alone.

Notebooks under the default gdsfactory backend are unaffected — the
redirected imports resolve to the same objects.

Worth noting for #100: `glayout_opamp.ipynb` and `GLayout_Cells.ipynb`,
which currently time out at 180 s under gdsfactory, complete in 89 s and
53 s under gdstk.
