### PR TITLE
Fixing LVS errors for diff_pair

### DIFF
--- a/src/glayout/cells/composite/diffpair_cmirror_bias/diff_pair_cmirrorbias.py
+++ b/src/glayout/cells/composite/diffpair_cmirror_bias/diff_pair_cmirrorbias.py
@@ -96,6 +96,7 @@ def diff_pair_ibias(
         fingers=half_diffpair_params[2],
         rmult=rmult,
         dum_net='B',
+        with_pin_labels=False,
     )
     # add antenna diodes if that option was specified
     diffpair_centered_ref = prec_ref_center(center_diffpair_comp)
@@ -201,16 +202,17 @@ def diff_pair_ibias(
     # cmirror dummies on a per-cell floating net. sky130 magic merges
     # the floating dummies into the bulk so the schematic must keep
     # them tied to VB or magic counts an extra net.
-    ## HACK: Note that this is a hack for magic LVS, and it's likely incorrect
-    ##       we probably want to fix it properly
-    _dummies_tied = (pdk.name.lower() == "sky130")
+    # Extraction shows the merged cmirror dummy as `B B B B` on gf180 too:
+    # with_tie=True draws a welltie ring that IS the bulk net, and the dummy
+    # contacts land on it. The old sky130-only condition described a difference
+    # that does not exist.
     cmirror.info['netlist'] = current_mirror_netlist(
         pdk,
         width=diffpair_bias[0],
         length=diffpair_bias[1],
         fingers=1,
         multipliers=diffpair_bias[2],
-        dummies_tied_to_bulk=_dummies_tied,
+        dummies_tied_to_bulk=True,
     )
 
     # add cmirror — bump y-offset enough that the LVPWELL paddings of the

--- a/src/glayout/cells/elementary/diff_pair/diff_pair.py
+++ b/src/glayout/cells/elementary/diff_pair/diff_pair.py
@@ -77,7 +77,7 @@ def add_df_labels(df_in: Component,
 		df_in.add(compref)
 	return df_in.flatten() 
 
-def diff_pair_netlist(fetL: Component, fetR: Component, pdk: Optional[MappedPDK] = None, dum_net: Optional[str] = None) -> Netlist:
+def diff_pair_netlist(fetL: Component, fetR: Component, pdk: Optional[MappedPDK] = None, dum_net: Optional[str] = None, substrate_tap: bool = True) -> Netlist:
 	diff_pair_netlist = Netlist(circuit_name='DIFF_PAIR', nodes=['VP', 'VN', 'VDD1', 'VDD2', 'VTAIL', 'B'])
 
 	# The physical layout uses an AB/BA common-centroid placement with four
@@ -97,7 +97,7 @@ def diff_pair_netlist(fetL: Component, fetR: Component, pdk: Optional[MappedPDK]
 	# layout context (extra tap rings, shared pwell paths) physically forces
 	# the dummies onto a different net than the standalone-cell extraction.
 	if dum_net is None:
-		dum_net = 'B' if (pdk is not None and pdk.name.lower() == 'sky130') else 'dum'
+		dum_net = 'B' if substrate_tap else 'dum'
 	for net, fet in (('VDD1', fetL), ('VDD1', fetL), ('VDD2', fetR), ('VDD2', fetR)):
 		gate = 'VP' if net == 'VDD1' else 'VN'
 		diff_pair_netlist.connect_netlist(
@@ -119,6 +119,7 @@ def diff_pair(
 	dummy: Union[bool, tuple[bool, bool]] = True,
 	substrate_tap: bool=True,
 	dum_net: Optional[str] = None,
+	with_pin_labels: bool = True,
 ) -> Component:
 	"""create a diffpair with 2 transistors placed in two rows with common centroid place. Sources are shorted
 	width = width of the transistors
@@ -243,18 +244,20 @@ def diff_pair(
 
 	component = component_snap_to_grid(rename_ports_by_orientation(diffpair))
 
-	component.info['netlist'] = diff_pair_netlist(fetL, fetR, pdk=pdk, dum_net=dum_net)
+	component.info['netlist'] = diff_pair_netlist(fetL, fetR, pdk=pdk, dum_net=dum_net, substrate_tap=substrate_tap)
 
-	# gf180 LVS uses klayout's official deck which strictly requires named
-	# pin labels on met*_label layers — without them, klayout extracts the
-	# cell with only an implicit substrate port and LVS fails. sky130 LVS
-	# via magic+netgen tolerates missing labels, so only emit the labels
-	# for gf180. The B (bulk) label needs `substrate_tap=True` since it
-	# anchors on `tap_N_top_met_S`, which only exists when the diffpair's
-	# tap ring is drawn. Composite cells suppress this via GLAYOUT_NO_PIN_LABELS
-	# so inner labels don't leak into the parent cell's GDS.
-	import os
-	if pdk.name.lower() == "gf180" and substrate_tap and not os.environ.get("GLAYOUT_NO_PIN_LABELS"):
+	# gf180 LVS uses klayout's official deck, which requires named pin labels on
+	# met*_label layers; without them klayout extracts only an implicit substrate
+	# port. sky130's magic+netgen tolerates missing labels, so emit for gf180
+	# only. B anchors on tap_N_top_met_S, which exists only when substrate_tap
+	# draws the ring.
+	#
+	# `with_pin_labels=False` lets a composite parent suppress these so they
+	# don't leak into the parent's flattened GDS and become extra top-level pins
+	# under klayout's --top_lvl_pins. Replaces the old GLAYOUT_NO_PIN_LABELS env
+	# var: @cell keys its cache on arguments, so flipping an env var between two
+	# otherwise-identical calls returns the stale cached component.
+	if pdk.name.lower() == "gf180" and substrate_tap and with_pin_labels:
 		component = add_df_labels(component, pdk)
 	return component
 


### PR DESCRIPTION
The p-cell was showing an extra top-level pin for which the label was present in GDS, but the net was internal in the reference netlist. Fixed the error for both.  Added the with_pin_labels option to suppress unnecessary layout labels so that internal nets are not extracted as top-level ports. The layout-driven substrate_tap parameter ensures dummy transistors are tied to the bulk net whenever a substrate tap is present, matching the extracted layout for both sky130 and gf180, thereby eliminating dummy net LVS mismatches.