### PR TITLE
gf180 mimcap: real model name, and emit a capacitor rather than a subckt call

### DIFF
--- a/src/glayout/pdk/gf180_mapped/gf180_mapped.py
+++ b/src/glayout/pdk/gf180_mapped/gf180_mapped.py
@@ -131,7 +131,12 @@ gf180_mapped_pdk = MappedPDK(
 	models={
         'nfet': 'nfet_03v3',
 		'pfet': 'pfet_03v3',
-		'mimcap': 'mimcap_1p0fF'
+		# The PDK names these cap_mim_<density>fF: 1f0, 1f5 or 2f0.
+		# 'mimcap_1p0fF' does not exist -- prefix reversed, 'p' for 'f' --
+		# so the reference netlist named a model the LVS reader could not
+		# pair with the cap_mim_* it extracts, in every cell with a cap.
+		# Which density to use is a process decision, not the generator's.
+		'mimcap': 'cap_mim_2f0fF'
     },
     layers=LAYER,
     pdk_files=pdk_files,


### PR DESCRIPTION
Two small things that kept the gf180 mimcap out of every LVS run.

**The model name did not exist.** `gf180_mapped.py` mapped `'mimcap'` to
`cap_mim_1p0fF`, which is not in the PDK. The three real models are
`cap_mim_1f0fF`, `cap_mim_1f5fF` and `cap_mim_2f0fF`. Any netlist emitted for
a gf180 mimcap named a device the simulator and the LVS reader had never
heard of.

**`X` is a subcircuit call, not a capacitor.** The netlist emitted

```
X1 V1 V2 cap_mim_2f0fF l={l} w={w}
```

so the LVS reader built a subcircuit instance and never a capacitor device.
The extracted MIM then had nothing to pair with and was reported as a
layout-only device, no matter how the schematic side was arranged. The fets
go through an equivalent `X`->`M` rewrite in the gf180 runner for the same
reason.

In the opamp this was the last mismatch standing: with `C1` it pairs and the
cell matches. Verified with `tests/lvs/run_cell_lvs.py --pdk gf180`; needs
\#108 for the runner to extract the MIM at all.
