### PR TITLE
transmission_gate: pass tie_layers through to the FETs

### DIFF
--- a/src/glayout/cells/elementary/transmission_gate/transmission_gate.py
+++ b/src/glayout/cells/elementary/transmission_gate/transmission_gate.py
@@ -172,8 +172,8 @@ def  transmission_gate(
     top_level = Component()
 
     #two fets
-    nfet = nmos(pdk, width=width[0], fingers=fingers[0], multipliers=multipliers[0], with_dummy=True, with_dnwell=False,  with_substrate_tap=False, length=length[0], **kwargs)
-    pfet = pmos(pdk, width=width[1], fingers=fingers[1], multipliers=multipliers[1], with_dummy=True, with_substrate_tap=False, length=length[1], **kwargs)
+    nfet = nmos(pdk, width=width[0], fingers=fingers[0], multipliers=multipliers[0], with_dummy=True, with_dnwell=False,  with_substrate_tap=False, length=length[0], tie_layers=tie_layers, **kwargs)
+    pfet = pmos(pdk, width=width[1], fingers=fingers[1], multipliers=multipliers[1], with_dummy=True, with_substrate_tap=False, length=length[1], tie_layers=tie_layers, **kwargs)
     nfet_ref = top_level << nfet
     pfet_ref = top_level << pfet 
     pfet_ref = rename_ports_by_orientation(pfet_ref.mirror_y())


### PR DESCRIPTION
The signature has accepted tie_layers since the parameter was added, but the value was never forwarded to nmos()/pmos() -- it was read once and dropped, so callers asking for anything other than the default silently got the default.

Both FETs already accept the argument; this just stops discarding it. No change for callers using the ("met2","met1") default.