### PR TITLE
Fix PrettyPrint dependency compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       # only. Keeping the environment small is what makes this job fast
       # enough to run on every push.
       - name: Install test dependencies
-        run: pip install pytest gdstk numpy pandas pydantic docopt
+        run: pip install pytest gdstk numpy pandas pydantic docopt 'prettyprinttree>=1.36.4,<2'
 
       # The heavier DRC/LVS workflows run the gdsfactory backend (Python
       # 3.10, gdsfactory 7.7), so gdstk currently has no CI coverage at all.

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setup(
         # `ModuleNotFoundError: No module named 'docopt'` and the deck
         # never runs.
         "docopt",
-        "prettyprint",
-        "prettyprinttree",
+        "prettyprinttree>=1.36.4,<2",
         "gdstk",
         "svgutils",
         "nltk",

--- a/tests/test_port_tree.py
+++ b/tests/test_port_tree.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+class PortTreeTests(unittest.TestCase):
+    def test_print_writes_the_port_hierarchy(self) -> None:
+        from glayout.backend import Component
+        from glayout.util.port_utils import PortTree
+
+        component = Component("demo")
+        component.add_port(
+            name="device_gate_N",
+            center=(0, 0),
+            width=1,
+            orientation=90,
+            layer=(1, 0),
+        )
+
+        with TemporaryDirectory() as directory:
+            output = Path(directory) / "ports.txt"
+            PortTree(component).print(savetofile=True, outfile_name=str(output))
+
+            self.assertTrue(output.is_file())
+            text = output.read_text()
+            self.assertIn("demo", text)
+            self.assertIn("device", text)
+            self.assertIn("gate", text)
+            self.assertIn("N", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the unused `prettyprint` package from the base installation
- constrain `PrettyPrintTree` to `>=1.36.4,<2`, whose API matches the existing `PortTree.print()` call
- install that renderer in the lightweight unit-test job, which intentionally does not install the package's full dependency set
- add a regression test that verifies `PortTree.print(savetofile=True)` writes the expected hierarchy

## Why

A clean Python 3.11 installation of current `main` resolves both `prettyprint 0.1.5` and `prettyprinttree 2.0.2`. On the case-insensitive Windows filesystem used for reproduction, their `prettyprint/` and `PrettyPrint/` package trees collide. The imports in `port_utils.py` then fall through to the no-op shim, so `PortTree.print()` silently produces no file.

Removing only the unused package is not sufficient: `PrettyPrintTree 2.0.2` changed its constructor API and raises `TypeError` for the existing `default_orientation` option. Version 1.36.4 has the compatible API and already ships a universal `py3-none-any` wheel.

The original report concerned Apple Silicon. I have not reproduced on arm64 macOS, so this PR limits its claim to the dependency conflict and API mismatch verified on Windows/Python 3.11.

## Tests

- `python -m pytest -q tests/test_port_tree.py` — 1 passed
- `python -m pytest -q tests/test_port_tree.py tests/test_import_paths.py tests/test_repo_layout.py` — 9 passed
- `python -m pytest -q tests --ignore=tests/test_cells_layout.py` — 26 passed, 16 subtests passed
- `.github/workflows/tests.yml` parsed successfully with PyYAML
- regression check with the dependencies selected by current `setup.py` (`prettyprint 0.1.5` + `PrettyPrintTree 2.0.2`) — new test fails because the output file is not created

The passing runs report existing Pydantic v2 deprecation warnings; this change does not add or address them.

## Review status

This is intentionally a draft while awaiting maintainer direction in #78. It preserves the current `PortTree` API and avoids broader renderer or packaging refactors.

Closes #78

Assisted-by: OpenAI Codex
